### PR TITLE
Hotfix: Fix local baseURL

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -3,7 +3,7 @@ import dotenv from 'dotenv';
 
 dotenv.config();
 
-const baseUrl = "/";
+const baseUrl = "/local/";
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {


### PR DESCRIPTION
_(Note: Please do not change this in the future. The use of a distinct `baseURL` for local builds helps us to avoid issues in the staging environment that can be hard to trace without prior experience.)_