### PR TITLE
Add Collapsing Element to Code Block

### DIFF
--- a/docs/products/data-management/dataaccess/index.mdx
+++ b/docs/products/data-management/dataaccess/index.mdx
@@ -68,8 +68,9 @@ The AWS retrospective resource is the primary publicly available source for the 
 
 Jupyter notebook instructions for processing NWM Zarr and NetCDF output formats [here](https://github.com/CIROH-UA/data_access_example/)
 
-An example of pulling data from the channel output zarr 2.1 archive and writing the results to csv follows:
-
+<details>
+<summary> Click to see an example of pulling data from the channel output zarr 2.1 archive and writing the results to csv. </summary>
+<br/>
 ```py
 '''
 #install these libraries if they aren't already installed
@@ -124,7 +125,7 @@ dan.ames@byu.edu
 '''
 
 ```
-
+</details>
 #### Google – Operational NWM Data
 
 Google hosts the most complete operational data archive of inputs and outputs from the National Water Model, with nearly every file since August 2018. The Google open data registry provides additional explanations [here](https://console.cloud.google.com/marketplace/product/noaa-public/national-water-model?project=explore-ai-387703).


### PR DESCRIPTION
Improving the flow of reading for the average user who is just learning about the national water model and data access. Smoothing the transition from the existing code block example to explanations about the other data directories by "hiding" the code block in the collapsing section. 

## Additions
Added code 
-Added HTML tags for collapsing section on this page: /docs/products/data-managment/dataaccess/index.mdx
-Changes are on lines 71, 72, 73, 127 and 128

## Removals

-Line 71 was removed and reworded. 

## Changes

-None of the actual text is changed. Also checked for typos in my own work

## Testing

## Screenshots
-Showing menu open...
<img width="1440" height="900" alt="Code Block Open" src="https://github.com/user-attachments/assets/c834d95f-822d-401d-bac0-af819c5876f8" />
-Showing the menu closed...
<img width="1440" height="900" alt="Code Block Closed" src="https://github.com/user-attachments/assets/94290cf0-e2e2-465f-aa7b-9e91b543a07c" />


## Notes

-Happy to move over to y'all's new hub. 

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
