### PR TITLE
Update CIROH-2i2c access requests to streamline ticket submissions and clarify instructions

### DIFF
--- a/docs/services/cloudservices/2i2c/custom-images.mdx
+++ b/docs/services/cloudservices/2i2c/custom-images.mdx
@@ -26,18 +26,17 @@ If you have a request for creating custom images, then please follow these instr
 conda env export -n ENVNAME > environment.yml
 ```
 
-### 2. Submit a Request Form:
+### 2. Open a GitHub Ticket
 
+- Open a ticket in the [CIROH image repository](https://github.com/CIROH-UA/awi-ciroh-image/issues).
+- Describe the custom image or software changes you need.
+- If relevant, attach or paste the `environment.yml` file you created in step 1.
 
-- Click on the link below to access the Jupyterhub (2i2c) Software Install form. 
-- Select Install Software on CIROH 2i2c JupyterHub as a reason for request. 
-- Fill out remaining sections of the form and submit it.
+<Link class="button button--active button--primary" to="https://github.com/CIROH-UA/awi-ciroh-image/issues">Open a Custom Image Ticket</Link>
 
-<Link class="button button--active button--primary" to="https://forms.office.com/Pages/ResponsePage.aspx?id=jnIAKtDwtECk6M5DPz-8p4IIpHdEnmhNgjOa9FjrwGtUNUoyV1UxNFIzV1AyTDhTNzdOT1Q5NVlLTC4u"> JupyterHub (2i2c) Software Install Form</Link>
+### 3. Follow up with the CIROH team if needed
 
-### 3. Share your environment.yml file with CIROH-IT support
-
-- After submitting the request form, attach the environment.yml file you created in step 1 to an email and send it to ciroh-it-support@ua.edu
+- If the team has questions about your request, they will follow up on the GitHub ticket.
 
 
  

--- a/docs/services/cloudservices/2i2c/index.mdx
+++ b/docs/services/cloudservices/2i2c/index.mdx
@@ -99,7 +99,7 @@ The per user storage quota is currently set to 250 GB.
 
 ### Software currently deployed on CIROH-2i2c JupyterHub
 
-Please refer to the [Dockerfile](https://github.com/2i2c-org/awi-ciroh-image/blob/main/Dockerfile) for the list of software currently deployed on CIROH-2i2c JupyterHub.
+Please refer to the [Dockerfile](https://github.com/CIROH-UA/awi-ciroh-image/blob/main/Dockerfile) for the list of software currently deployed on CIROH-2i2c JupyterHub.
 
 ### Cost of Use
 

--- a/docs/services/cloudservices/2i2c/index.mdx
+++ b/docs/services/cloudservices/2i2c/index.mdx
@@ -49,11 +49,11 @@ If you are participating in an event that uses the workshop environment, ask you
 -----
 ## Requesting Software Installation on CIROH-2i2c JupyterHub
 
-Before making a request, please refer to the [Dockerfile](https://github.com/2i2c-org/awi-ciroh-image/blob/main/Dockerfile) for the list of software currently deployed on CIROH-2i2c JupyterHub.
+Before making a request, please refer to the [Dockerfile](https://github.com/CIROH-UA/awi-ciroh-image/blob/main/Dockerfile) for the list of software currently deployed on CIROH-2i2c JupyterHub.
 
-If your software in not listed in this file, please submit the form below to request new software installation on 2i2c JupyterHub.
+If your software is not listed there, please open a ticket in the [CIROH image repository](https://github.com/CIROH-UA/awi-ciroh-image/issues) and describe the requested addition or change. If helpful, attach an `environment.yml` file exported from your conda environment.
 
-<Link class="button button--active button--primary" to="https://forms.office.com/Pages/ResponsePage.aspx?id=jnIAKtDwtECk6M5DPz-8p4IIpHdEnmhNgjOa9FjrwGtUNUoyV1UxNFIzV1AyTDhTNzdOT1Q5NVlLTC4u"> JupyterHub (2i2c) Software Install Form</Link>
+<Link class="button button--active button--primary" to="https://github.com/CIROH-UA/awi-ciroh-image/issues"> Open a Custom Image Ticket</Link>
 
 
 ---
@@ -115,7 +115,7 @@ These external websites provide general guidance for getting the most out of 2i2
 - [2i2c Infrastructure Documentation](https://infrastructure.2i2c.org/)
 - [2i2c Homepage](https://2i2c.org/)
 - [2i2c Blog](https://2i2c.org/blog/)
-- [GitHub template for CIROH 2i2c images](https://github.com/2i2c-org/awi-ciroh-image)
+- [GitHub repo for CIROH 2i2c images](https://github.com/CIROH-UA/awi-ciroh-image)
 
 Alternatively, check out Hub's specialized documentation below for information specific to CIROH's 2i2c deployment!
 

--- a/src/components/InfrastructureAccess/CIROHJupyterHub.js
+++ b/src/components/InfrastructureAccess/CIROHJupyterHub.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import Link from '@docusaurus/Link';
 import { useColorMode } from '@docusaurus/theme-common';
 import InfrastructureAccessSection from './InfrastructureAccessSection';
 
@@ -9,38 +8,19 @@ const CIROHJupyterHub = () => {
 
   const steps = [
     {
-      title: "Submit Infrastructure Request",
-      description: "Submit a GitHub template request detailing your project requirements and specifications.",
+      title: "Submit Unified Access Request",
+      description: "Use the same Cloud Infrastructure Request Form used for public cloud access to request CIROH-2i2c JupyterHub resources, including CPU or GPU access for your project or workshop.",
       buttons: [
         {
           text: "Cloud Infrastructure Request Form",
           link: "https://github.com/CIROH-UA/NGIAB-CloudInfra/issues/new?template=case_studies_call_template.yml"
         }
       ],
-      details: "Our team will review your request and assist you in obtaining the necessary access."
-    },
-    {
-      title: "Request Individual Access",
-      description: "After your project has been approved, submit one of the following forms to get access to CIROH-2i2c JupyterHub environments.",
-      buttons: [
-        {
-          text: "CPU Access Request Form",
-          link: "https://forms.office.com/Pages/ResponsePage.aspx?id=jnIAKtDwtECk6M5DPz-8p4IIpHdEnmhNgjOa9FjrwGtUNUoyV1UxNFIzV1AyTDhTNzdOT1Q5NVlLTC4u"
-        },
-        {
-          text: "GPU Access Request Form",
-          link: "https://forms.office.com/r/mkrVJzyg9u"
-        }
-      ],
       details: (
         <>
-            You will need to submit your GitHub username for this request. If you do not currently have a GitHub account, follow the instructions at{' '}
-            <a href="https://docs.github.com/en/get-started/start-your-journey/creating-an-account-on-github" target="_blank" rel="noopener noreferrer" style={{color: '#06b6d4', textDecoration: 'underline'}}
-            >
-                GitHub
-            </a>.
+          Include your GitHub username and note whether you need CPU, GPU, and/or related AWS or Google Cloud resources. Our team will review the request and follow up with access details.
         </>
-    )
+      )
     }
   ];
 
@@ -97,7 +77,7 @@ const CIROHJupyterHub = () => {
             marginBottom: '1rem',
             fontSize: '1rem'
           }}>
-            To request custom images:
+            To request custom images or software updates:
           </p>
           
           <ol style={{
@@ -106,7 +86,7 @@ const CIROHJupyterHub = () => {
             color: 'var(--ifm-color-emphasis-800)'
           }}>
             <li style={{marginBottom: '0.75rem', lineHeight: 1.6}}>
-              Create an{' '}
+              Optionally create an{' '}
               <code style={{
                 padding: '0.2rem 0.5rem',
                 background: isDark ? 'rgba(71, 85, 105, 0.4)' : 'rgba(226, 232, 240, 0.8)',
@@ -121,12 +101,12 @@ const CIROHJupyterHub = () => {
               {' '}file by exporting your conda environment.
             </li>
             <li style={{lineHeight: 1.6}}>
-              Fill out the CIROH-2i2c JupyterHub Software Install form.
+              Open a ticket in the CIROH image repository and describe the software or image changes you need.
             </li>
           </ol>
           
           <a 
-            href="https://forms.office.com/Pages/ResponsePage.aspx?id=jnIAKtDwtECk6M5DPz-8p4IIpHdEnmhNgjOa9FjrwGtUNUoyV1UxNFIzV1AyTDhTNzdOT1Q5NVlLTC4u"
+            href="https://github.com/CIROH-UA/awi-ciroh-image/issues"
             target="_blank"
             rel="noopener noreferrer"
             style={{
@@ -145,7 +125,7 @@ const CIROHJupyterHub = () => {
               textDecoration: 'none'
             }}
           >
-            JupyterHub Software Install Form
+            Open a Custom Image Ticket
             <svg width={18} height={18} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
               <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
               <polyline points="15 3 21 3 21 9" />

--- a/src/components/InfrastructureAccess/PublicCloud.js
+++ b/src/components/InfrastructureAccess/PublicCloud.js
@@ -9,8 +9,8 @@ const PublicCloud = () => {
 
   const steps = [
     {
-      title: "Requesting Project Access",
-      description: "Primary Investigators (PIs) or Workshop Leads leading CIROH projects or workshops may use this form to request cloud computing resources on AWS or Google Cloud. Access is available to all consortium members and partners.",
+      title: "Submit Unified Access Request",
+      description: "Primary Investigators (PIs) or Workshop Leads leading CIROH projects or workshops should use this single form to request AWS, Google Cloud, and/or CIROH-2i2c JupyterHub access. Access is available to all consortium members and partners.",
       buttons: [
         {
           text: "Cloud Infrastructure Request Form",
@@ -19,19 +19,20 @@ const PublicCloud = () => {
       ],
       details: (
         <>
-          <p style={{marginBottom: '0.75rem'}}>1. Submit a GitHub template request detailing your project requirements and specifications.</p>
-          <p style={{marginBottom: '0.75rem'}}>2. Our team will review your request and assist you in obtaining the necessary access.</p>
+          <p style={{marginBottom: '0.75rem'}}>1. Submit one GitHub request outlining the public cloud and/or 2i2c resources your project needs.</p>
+          <p style={{marginBottom: '0.75rem'}}>2. Indicate whether you need AWS, Google Cloud, and/or CIROH-2i2c CPU/GPU access for your team.</p>
+          <p style={{marginBottom: '0.75rem'}}>3. Our team will review the request, coordinate provisioning, and follow up if more information is needed.</p>
           <p style={{marginBottom: '0.75rem'}}>
             <strong>Reference:</strong> Please refer to{' '}
             <a 
-              href="https://github.com/CIROH-UA/NGIAB-CloudInfra/issues?q=is%3Aissue%20is%3Aclosed%20label%3Agoogle%2C%222i2c%20JupyterHub%22%2Caws%20" 
+              href="https://github.com/CIROH-UA/NGIAB-CloudInfra/issues" 
               target="_blank" 
               rel="noopener noreferrer"
               style={{color: '#06b6d4', textDecoration: 'underline'}}
             >
-              this link
+              the issue tracker
             </a>
-            {' '}for references to submitted forms.
+            {' '}for examples of previous requests.
           </p>
         </>
       )
@@ -57,7 +58,7 @@ const PublicCloud = () => {
         borderLeft: '4px solid var(--ifm-color-info)'
       }}>
         <p style={{margin: 0, color: 'var(--ifm-color-emphasis-800)'}}>
-          <strong>Note:</strong> If using CIROH-2i2c services, please see the "Accessing CIROH-2i2c JupyterHub" section below for additional steps.
+          <strong>Note:</strong> This same request process now covers CIROH-2i2c JupyterHub access, so you only need to submit one request for cloud and JupyterHub needs.
         </p>
       </div>
     </div>

--- a/src/components/InfrastructureAccess/WorkshopSupport.js
+++ b/src/components/InfrastructureAccess/WorkshopSupport.js
@@ -43,4 +43,4 @@ const WorkshopSupport = () => {
   );
 };
 
-export default WorkshopSupport;
+export default WorkshopSupport; 


### PR DESCRIPTION
This pull request updates the documentation and user interface to streamline and unify the process for requesting access to CIROH-2i2c JupyterHub and public cloud resources. It replaces multiple forms and outdated instructions with a single, GitHub-based workflow for both infrastructure access and custom image/software requests. The changes also update repository links and clarify steps for users.

**Unified Access Request Process:**

* Both the CIROH-2i2c JupyterHub and public cloud access workflows now use a single "Cloud Infrastructure Request Form" via GitHub, replacing separate forms for CPU/GPU and project access. Instructions and button labels have been updated to reflect this unified process. [[1]](diffhunk://#diff-b9c6b05f0d6e283899b7b5893fe4631a8260c63d616720fc8e4fbdaef595abb2L12-R21) [[2]](diffhunk://#diff-eb9a127cc26f7fae264880f0cafc5d31f3732217888db29f642ca6dda0dce3f7L12-R13) [[3]](diffhunk://#diff-eb9a127cc26f7fae264880f0cafc5d31f3732217888db29f642ca6dda0dce3f7L22-R35) [[4]](diffhunk://#diff-eb9a127cc26f7fae264880f0cafc5d31f3732217888db29f642ca6dda0dce3f7L60-R61)

**Custom Image and Software Requests:**

* The process for requesting custom images or software installations has been updated to use GitHub tickets in the CIROH image repository, replacing the previous Microsoft Forms workflow. Documentation and UI elements have been revised to guide users through the new process. [[1]](diffhunk://#diff-b8b20d10d02547c423407511e4452d87bd0c878087ff5cf1f6e07d580a2c39a9L29-R39) [[2]](diffhunk://#diff-90e3cab2823d71a26d7c03dd58b6deb72b3a7169079b6e1e4120f7c4ac70740bL52-R56) [[3]](diffhunk://#diff-b9c6b05f0d6e283899b7b5893fe4631a8260c63d616720fc8e4fbdaef595abb2L100-R80) [[4]](diffhunk://#diff-b9c6b05f0d6e283899b7b5893fe4631a8260c63d616720fc8e4fbdaef595abb2L109-R89) [[5]](diffhunk://#diff-b9c6b05f0d6e283899b7b5893fe4631a8260c63d616720fc8e4fbdaef595abb2L124-R109) [[6]](diffhunk://#diff-b9c6b05f0d6e283899b7b5893fe4631a8260c63d616720fc8e4fbdaef595abb2L148-R128)

**Repository Link Updates:**

* All references to the CIROH 2i2c image repository have been updated to use the new GitHub organization (`CIROH-UA/awi-ciroh-image`), ensuring users are directed to the correct location for documentation and requests. [[1]](diffhunk://#diff-90e3cab2823d71a26d7c03dd58b6deb72b3a7169079b6e1e4120f7c4ac70740bL52-R56) [[2]](diffhunk://#diff-90e3cab2823d71a26d7c03dd58b6deb72b3a7169079b6e1e4120f7c4ac70740bL118-R118)

**User Interface and Clarity Improvements:**

* Button labels, section titles, and step descriptions have been revised for clarity and consistency, reducing confusion and making the request process more intuitive for users. [[1]](diffhunk://#diff-b9c6b05f0d6e283899b7b5893fe4631a8260c63d616720fc8e4fbdaef595abb2L12-R21) [[2]](diffhunk://#diff-b9c6b05f0d6e283899b7b5893fe4631a8260c63d616720fc8e4fbdaef595abb2L100-R80) [[3]](diffhunk://#diff-b9c6b05f0d6e283899b7b5893fe4631a8260c63d616720fc8e4fbdaef595abb2L148-R128) [[4]](diffhunk://#diff-eb9a127cc26f7fae264880f0cafc5d31f3732217888db29f642ca6dda0dce3f7L12-R13) [[5]](diffhunk://#diff-eb9a127cc26f7fae264880f0cafc5d31f3732217888db29f642ca6dda0dce3f7L22-R35) [[6]](diffhunk://#diff-eb9a127cc26f7fae264880f0cafc5d31f3732217888db29f642ca6dda0dce3f7L60-R61)

**Code Cleanup:**

* Unused imports have been removed from `CIROHJupyterHub.js` to simplify the codebase.