### PR TITLE
CI/CD: Add support for additional secrets

### DIFF
--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -99,6 +99,8 @@ jobs:
       env:
           ZOTERO_API_KEY: ${{ secrets.ZOTERO_API_KEY }}
           ZOTERO_CIROH_GROUP_ID: ${{ secrets.ZOTERO_CIROH_GROUP_ID }}
+          ZOTERO_STAGING_API_KEY: ${{ secrets.ZOTERO_STAGING_API_KEY }}
+          ZOTERO_CIROH_STAGING_GROUP_ID: ${{ secrets.ZOTERO_CIROH_STAGING_GROUP_ID }}
           CAPTCHA_KEY: ${{ secrets.CAPTCHA_KEY }}
           S3_BUCKET_NAME: ${{ secrets.S3_BUCKET_NAME }}
           S3_ACCESS_KEY: ${{ secrets.S3_ACCESS_KEY }}


### PR DESCRIPTION
To allow testing and support of #113.
- `ZOTERO_STAGING_API_KEY`
- `ZOTERO_CIROH_STAGING_GROUP_ID`