### PR TITLE
Reorganize navbar to emphasize cyberinfra

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -316,14 +316,15 @@ const config = {
               ],
             },
             {
-              label: "Operations",
+              label: "Cyberinfrastructure",
+              position: "left",
+              type: "doc",
+              docId: "services/intro",
+            },
+            {
+              label: "Community",
               position: "left",
               items: [
-                {
-                  type: "doc",
-                  docId: "services/intro",
-                  label: "IT Services",
-                },
                 {
                   type: "doc",
                   docId: "policies/intro",
@@ -333,12 +334,6 @@ const config = {
                   href: "/working-groups",
                   label: "Working Groups",
                 },
-              ],
-            },
-            {
-              label: "Community",
-              position: "left",
-              items: [
                 {
                   href: "/impact",
                   label: "Community Impact",

--- a/src/components/InfrastructureAccess/CIROHJupyterHub.js
+++ b/src/components/InfrastructureAccess/CIROHJupyterHub.js
@@ -13,7 +13,7 @@ const CIROHJupyterHub = () => {
       buttons: [
         {
           text: "Cloud Infrastructure Request Form",
-          link: "https://github.com/CIROH-UA/NGIAB-CloudInfra/issues/new?template=jupyterhub_access_request.yml"
+          link: "https://github.com/CIROH-UA/NGIAB-CloudInfra/issues/new?template=case_studies_call_template.yml"
         }
       ],
       details: (

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -24,7 +24,7 @@ export default function Home() {
             }
             buttons={[
               { label: "Publications", href: "/publications", primary: true },
-              { label: "IT Services", href: "/docs/services/access" },
+              { label: "Cyberinfrastructure", href: "/docs/services/access" },
             ]}
             notice={
               "CIROH Hub is the new home for content from CIROH Portal and DocuHub."


### PR DESCRIPTION
Self-explanatory; pictured below. Research Portal and Documentation dropdowns were left untouched.

<img width="1190" height="376" alt="image" src="https://github.com/user-attachments/assets/08b4fec2-5f10-4397-852a-fe2d54dde381" />

The main reason I'm submitting this as a standalone PR is that the "Policies" section has been moved, which might be subject to broader interest/scrutiny.