### PR TITLE
Add events page

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -268,6 +268,10 @@ const config = {
                   label: "Presentations",
                 },
                 {
+                  href: "/events",
+                  label: "Events",
+                },
+                {
                   href: "/publications",
                   label: "Publications",
                 },

--- a/src/components/HydroShareEventCards/ModalEventPresentations.js
+++ b/src/components/HydroShareEventCards/ModalEventPresentations.js
@@ -68,7 +68,7 @@ function filterAndSortPresentations(presentations, filterSearch, sortType, sortD
  * @param {Array} presentations - List of presentations to display.
  * @param {boolean} loadError - Whether there was an error loading the presentations.
  */
-export default function EventPresentationsModal({ show, onClose, title, presentations, loadError }) {
+export default function ModalEventPresentations({ show, onClose, title, presentations, loadError }) {
     const defaultImage = 'https://ciroh-portal-static-data.s3.us-east-1.amazonaws.com/presentation_placeholder.png';
 
     // Search / Sort State

--- a/src/components/HydroShareEventCards/ModalEventPresentations.js
+++ b/src/components/HydroShareEventCards/ModalEventPresentations.js
@@ -1,9 +1,13 @@
 import React, { useEffect, useMemo, useRef, useState, startTransition } from 'react';
+import { useTheme } from '@docusaurus/theme-common';
 import ReactDOM from 'react-dom';
 import HydroShareResourcesCards from "@site/src/components/HydroShareResourcesCards";
 import { FaWindowClose } from 'react-icons/fa';
 import { HiOutlineSortDescending, HiOutlineSortAscending, HiOutlineSearch } from 'react-icons/hi';
 import styles from './styles.module.css';
+import { useColorMode } from '@docusaurus/theme-common';
+import DatasetLightIcon from '@site/static/img/cards/datasets_logo_light.png';
+import DatasetDarkIcon from '@site/static/img/cards/datasets_logo_dark.png';
 
 const DEBOUNCE_MS = 1_000;
 
@@ -69,7 +73,9 @@ function filterAndSortPresentations(presentations, filterSearch, sortType, sortD
  * @param {boolean} loadError - Whether there was an error loading the presentations.
  */
 export default function ModalEventPresentations({ show, onClose, title, presentations, loadError }) {
-    const defaultImage = 'https://ciroh-portal-static-data.s3.us-east-1.amazonaws.com/presentation_placeholder.png';
+    const { colorMode } = useColorMode();
+    const isDarkTheme = colorMode === 'dark';
+    const defaultImage = isDarkTheme ? DatasetDarkIcon : DatasetLightIcon;
 
     // Search / Sort State
     const [searchInput, setSearchInput] = useState('');

--- a/src/components/HydroShareEventCards/ModalEventPresentations.js
+++ b/src/components/HydroShareEventCards/ModalEventPresentations.js
@@ -1,0 +1,269 @@
+import React, { useEffect, useMemo, useRef, useState, startTransition } from 'react';
+import ReactDOM from 'react-dom';
+import HydroShareResourcesCards from "@site/src/components/HydroShareResourcesCards";
+import { FaWindowClose } from 'react-icons/fa';
+import { HiOutlineSortDescending, HiOutlineSortAscending, HiOutlineSearch } from 'react-icons/hi';
+import styles from './styles.module.css';
+
+const DEBOUNCE_MS = 1_000;
+
+/**
+ * Filter and sort a list of presentation cards locally.
+ * @param {Array} presentations - List of presentation objects to filter/sort.
+ * @param {string} filterSearch - Search query to filter presentations by (matches title, description, authors, or dates).
+ * @param {string} sortType - Field to sort by ('modified', 'created', 'title', 'author').
+ * @param {string} sortDirection - Sort direction ('asc' or 'desc').
+ * @returns {Array} Filtered and sorted list of presentations.
+ */
+function filterAndSortPresentations(presentations, filterSearch, sortType, sortDirection) {
+    // Remove leading/trailing whitespace and make search case-insensitive
+    const query = (filterSearch || '').trim().toLowerCase();
+
+    // Search / Filter
+    const filtered = !query
+        ? presentations.slice()
+        : presentations.filter(presentation => {
+            const searchableFields = [
+                presentation.title,
+                presentation.description,
+                presentation.authors,
+                presentation.date_created,
+                presentation.date_last_updated,
+            ];
+            return searchableFields.some(field =>
+                typeof field === 'string' && field.toLowerCase().includes(query)
+            );
+        });
+
+    // Sort
+    filtered.sort((a, b) => {
+        let comparison = 0;
+        switch (sortType) {
+            case 'modified':
+                comparison = (a.date_last_updated || '').localeCompare(b.date_last_updated || '');
+                break;
+            case 'created':
+                comparison = (a.date_created || '').localeCompare(b.date_created || '');
+                break;
+            case 'title':
+                comparison = (a.title || '').localeCompare(b.title || '');
+                break;
+            case 'author':
+                comparison = (a.authors || '').localeCompare(b.authors || '');
+                break;
+            default:
+                comparison = 0;
+        }
+        return sortDirection === 'asc' ? comparison : -comparison;
+    });
+
+    return filtered;
+}
+
+/**
+ * Full-screen modal for displaying event presentations.
+ * @param {boolean} show - Whether the modal is visible.
+ * @param {function} onClose - Function to call when the modal is closed.
+ * @param {string} title - Title of the modal.
+ * @param {Array} presentations - List of presentations to display.
+ * @param {boolean} loadError - Whether there was an error loading the presentations.
+ */
+export default function EventPresentationsModal({ show, onClose, title, presentations, loadError }) {
+    const defaultImage = 'https://ciroh-portal-static-data.s3.us-east-1.amazonaws.com/presentation_placeholder.png';
+
+    // Search / Sort State
+    const [searchInput, setSearchInput] = useState('');
+    const [filterSearch, setFilterSearch] = useState('');
+    const [sortType, setSortType] = useState('modified');
+    const [sortDirection, setSortDirection] = useState('asc');
+    const debounceTimerRef = useRef(null);
+
+    // Reset search/sort state each time the modal closes so reopening is fresh
+    useEffect(() => {
+        if (!show) {
+            setSearchInput('');
+            setFilterSearch('');
+            setSortType('modified');
+            setSortDirection('asc');
+            if (debounceTimerRef.current) {
+                clearTimeout(debounceTimerRef.current);
+                debounceTimerRef.current = null;
+            }
+        }
+    }, [show]);
+
+    // Debounce search input to avoid excessive re-filtering while the user is typing
+    useEffect(() => {
+        if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current);
+
+        debounceTimerRef.current = setTimeout(() => {
+            setFilterSearch(String(searchInput || '').trim());
+        }, DEBOUNCE_MS);
+
+        return () => {
+            if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current);
+        };
+    }, [searchInput]);
+
+    // Immediate commit function for when the user presses Enter
+    const commitSearch = (q) => {
+        if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current);
+        setFilterSearch(String(q || '').trim());
+    };
+
+    // Prevent background scrolling while modal is open
+    useEffect(() => {
+        if (show) {
+            document.body.style.overflow = 'hidden';
+        } else {
+            document.body.style.overflow = '';
+        }
+        return () => {
+            document.body.style.overflow = '';
+        };
+    }, [show]);
+
+    // Filtered and sorted list (from search input and sort options) - memoized for performance
+    const displayedPresentations = useMemo(() => {
+        if (!Array.isArray(presentations)) return presentations;
+        return filterAndSortPresentations(presentations, filterSearch, sortType, sortDirection);
+    }, [presentations, filterSearch, sortType, sortDirection]);
+
+    // Don't render the modal at all if it's not shown
+    if (!show) return null;
+
+    // Counts for display above the search bar
+    const isLoaded = Array.isArray(presentations);
+    const totalCount = isLoaded ? presentations.length : 0;
+    const shownCount = isLoaded ? (displayedPresentations?.length || 0) : 0;
+
+    return ReactDOM.createPortal(
+        <div
+            className={`tw-fixed tw-inset-0 tw-z-50 tw-flex tw-items-center tw-justify-center tw-bg-slate-900/70 tw-backdrop-blur-sm ${styles.modalBelowNavbar}`}
+            onClick={onClose}
+        >
+            {/* Modal Content */}
+            <div
+                className="tw-relative tw-h-full tw-w-full tw-overflow-y-auto tw-rounded-xl tw-shadow-2xl tw-bg-white dark:tw-bg-[#060010]"
+                onClick={(e) => e.stopPropagation()}
+            >
+                {/* Close button */}
+                <button
+                    type="button"
+                    onClick={onClose}
+                    aria-label="Close"
+                    className="tw-absolute tw-top-4 tw-right-4 tw-inline-flex tw-cursor-pointer tw-items-center tw-justify-center tw-rounded-md tw-border tw-border-slate-400 tw-bg-white/80 tw-p-2 tw-text-slate-700 hover:tw-text-cyan-700 hover:tw-border-cyan-600 dark:tw-border-slate-600 dark:tw-bg-slate-700/50 dark:tw-text-slate-300 dark:hover:tw-text-cyan-300 hover:tw-shadow-md tw-transition"
+                >
+                    <FaWindowClose />
+                </button>
+
+                {/* Title, Search/Filter Bar, and Presentations Container */}
+                <div className="tw-h-full tw-w-full tw-p-6">
+                    {/* Title */}
+                    <h1 className="tw-mb-4 tw-pr-10 tw-text-2xl tw-font-semibold tw-text-center tw-text-cyan-700 dark:tw-text-cyan-300">
+                        {title} Presentations
+                    </h1>
+
+                    {/* Search and Filter Inputs */}
+                    {isLoaded && totalCount > 0 && (
+                        <div className="tw-flex tw-flex-col lg:tw-flex-row lg:tw-items-center lg:tw-justify-between tw-gap-4 tw-mb-6">
+                            {/* Counts */}
+                            <div className="tw-text-sm sm:tw-text-base tw-text-slate-600 dark:tw-text-slate-300">
+                                Showing{' '}
+                                <strong className="tw-font-semibold tw-text-slate-900 dark:tw-text-white">
+                                    {shownCount}
+                                </strong>{' '}
+                                of{' '}
+                                <strong className="tw-font-semibold tw-text-slate-900 dark:tw-text-white">
+                                    {totalCount}
+                                </strong>{' '}
+                                Presentations
+                            </div>
+
+                            {/* Search and Sort Form */}
+                            <form
+                                className="tw-flex tw-flex-col md:tw-flex-row md:tw-items-center tw-gap-3 tw-w-full lg:tw-w-auto"
+                                onSubmit={(e) => { e.preventDefault(); commitSearch(searchInput); }}
+                            >
+                                {/* Search Input */}
+                                <div className="tw-relative tw-w-full md:tw-w-[28rem]">
+                                    <span className="tw-pointer-events-none tw-absolute tw-left-3 tw-inset-y-0 tw-flex tw-items-center tw-text-slate-400 dark:tw-text-slate-500">
+                                        <HiOutlineSearch size={18} />
+                                    </span>
+                                    <input
+                                        type="text"
+                                        placeholder="Search by Title, Author, Description..."
+                                        className="tw-w-full tw-rounded-lg tw-border tw-border-slate-200/80 dark:tw-border-slate-700/80 tw-bg-white/80 dark:tw-bg-slate-900/50 tw-backdrop-blur tw-pl-10 tw-pr-3 tw-py-3 tw-text-sm tw-text-slate-900 dark:tw-text-white placeholder:tw-text-slate-400 dark:placeholder:tw-text-slate-500 focus:tw-outline-none focus:tw-ring-2 focus:tw-ring-cyan-500/30"
+                                        value={searchInput}
+                                        onChange={(e) => setSearchInput(e.target.value)}
+                                        onKeyDown={(e) => {
+                                            if (e.key === 'Enter') {
+                                                e.preventDefault();
+                                                commitSearch(e.currentTarget.value);
+                                            }
+                                        }}
+                                        onBlur={(e) => commitSearch(e.currentTarget.value)}
+                                    />
+                                </div>
+                                
+                                {/* Sort Inputs */}
+                                <div className="tw-flex tw-flex-wrap tw-gap-2 tw-items-center">
+                                    {/* Sort Type */}
+                                    <select
+                                        value={sortType}
+                                        onChange={(e) => setSortType(e.target.value)}
+                                        className="tw-rounded-lg tw-border tw-border-slate-200/80 dark:tw-border-slate-700/80 tw-bg-white/80 dark:tw-bg-slate-900/50 tw-backdrop-blur tw-px-3 tw-py-3 tw-text-sm tw-text-slate-900 dark:tw-text-white focus:tw-outline-none focus:tw-ring-2 focus:tw-ring-cyan-500/30"
+                                    >
+                                        <option value="modified">Last Updated</option>
+                                        <option value="created">Date Created</option>
+                                        <option value="title">Title</option>
+                                        <option value="author">Authors</option>
+                                    </select>
+                                    
+                                    {/* Sort Direction */}
+                                    <button
+                                        type="button"
+                                        aria-label={`Sort direction ${sortDirection}`}
+                                        className="tw-inline-flex tw-items-center tw-justify-center tw-rounded-lg tw-border tw-border-slate-200/80 dark:tw-border-slate-700/80 tw-bg-white/80 dark:tw-bg-slate-900/50 tw-backdrop-blur tw-px-3 tw-py-3 tw-text-slate-700 dark:tw-text-slate-200 hover:tw-border-cyan-500/40 hover:tw-text-cyan-700 dark:hover:tw-text-cyan-300 tw-transition"
+                                        onClick={() =>
+                                            startTransition(() =>
+                                                setSortDirection(d => (d === 'asc' ? 'desc' : 'asc'))
+                                            )
+                                        }
+                                    >
+                                        {sortDirection === 'asc'
+                                            ? <HiOutlineSortAscending size={20} />
+                                            : <HiOutlineSortDescending size={20} />}
+                                    </button>
+                                </div>
+                            </form>
+                        </div>
+                    )}
+
+                    {/* Presentations */}
+                    {presentations === null ? (
+                        <div id="selected-image-loader" className="tw-absolute tw-inset-0 tw-z-10 tw-pointer-events-none">
+                            <div className="tw-w-full tw-h-full tw-flex tw-items-center tw-justify-center">
+                                <span className="spinner-border" role="status">
+                                    <span className="visually-hidden">Loading...</span>
+                                </span>
+                            </div>
+                        </div>
+                    ) : totalCount === 0 ? (
+                        <div className="tw-flex tw-h-64 tw-items-center tw-justify-center tw-text-slate-600 dark:tw-text-slate-300">
+                            {loadError
+                                ? `Could not load presentations: ${loadError}`
+                                : 'No presentations are associated with this event yet.'}
+                        </div>
+                    ) : shownCount === 0 ? (
+                        <p className="tw-mt-10 tw-text-center tw-text-sm tw-text-slate-600 dark:tw-text-slate-300">
+                            No Presentations Found
+                        </p>
+                    ) : (
+                        <HydroShareResourcesCards resources={displayedPresentations} defaultImage={defaultImage} />
+                    )}
+                </div>
+            </div>
+        </div>
+        , document.body);
+}

--- a/src/components/HydroShareEventCards/index.js
+++ b/src/components/HydroShareEventCards/index.js
@@ -5,7 +5,7 @@ import { LuLayers3 } from 'react-icons/lu';
 import { HiOutlineGlobeAlt, HiOutlineUserGroup } from 'react-icons/hi';
 import { isPlaceholder, splitAuthors, StatTag, ActionLink } from '@site/src/components/HydroShareResourcesCards/shared';
 import { fetchResourcesFromCollection, fetchResourceCustomMetadata, fetchResourceImageUrls, } from '@site/src/components/HydroShareImporter';
-import EventPresentationsModal from './ModalEventPresentations';
+import ModalEventPresentations from './ModalEventPresentations';
 
 /**
  * Load event presentations for a given collection.
@@ -224,7 +224,7 @@ export function EventCard({ resource, defaultImage }) {
             </article>
             
             {/* Event Presentations Modal */}
-            <EventPresentationsModal
+            <ModalEventPresentations
                 show={showModal}
                 onClose={() => setShowModal(false)}
                 title={title}

--- a/src/components/HydroShareEventCards/index.js
+++ b/src/components/HydroShareEventCards/index.js
@@ -158,14 +158,14 @@ export function EventCard({ resource, defaultImage }) {
                                 </div>
                             ) : (
                                 <h3 className="tw-text-base sm:tw-text-lg tw-font-semibold tw-leading-snug tw-text-slate-900 dark:tw-text-white tw-line-clamp-2">
-                                    <a
-                                        href="#"
+                                    <button
+                                        type="button"
                                         onClick={openModal}
                                         title={`View presentations for ${title}`}
-                                        className="tw-no-underline tw-text-black hover:tw-text-cyan-700 dark:tw-text-white dark:hover:tw-text-cyan-300 tw-cursor-pointer"
+                                        className="tw-text-left tw-w-full tw-bg-transparent tw-border-0 tw-p-0 tw-no-underline [font:inherit] tw-text-black hover:tw-text-cyan-700 dark:tw-text-white dark:hover:tw-text-cyan-300 tw-cursor-pointer"
                                     >
                                         {title}
-                                    </a>
+                                    </button>
                                 </h3>
                             )}
                         </div>

--- a/src/components/HydroShareEventCards/index.js
+++ b/src/components/HydroShareEventCards/index.js
@@ -1,0 +1,256 @@
+import React, { useEffect, useState } from 'react';
+import { LiaExternalLinkSquareAltSolid } from 'react-icons/lia';
+import { FaGraduationCap } from 'react-icons/fa';
+import { LuLayers3 } from 'react-icons/lu';
+import { HiOutlineGlobeAlt, HiOutlineUserGroup } from 'react-icons/hi';
+import { isPlaceholder, splitAuthors, StatTag, ActionLink } from '@site/src/components/HydroShareResourcesCards/shared';
+import { fetchResourcesFromCollection, fetchResourceCustomMetadata, fetchResourceImageUrls, } from '@site/src/components/HydroShareImporter';
+import EventPresentationsModal from './ModalEventPresentations';
+
+/**
+ * Load event presentations for a given collection.
+ * @param {string} collectionId 
+ * @returns {Promise<Array>} List of presentation cards
+ */
+async function loadEventPresentations(collectionId) {
+    // Fetch presentations in the collection
+    const resources = await fetchResourcesFromCollection(collectionId);
+
+    // Map to card format and enrich with custom metadata and images
+    const mapped = resources.map(resource => ({
+        authors: (resource.authors || [])
+            .map(a => a.split(',').reverse().join(' '))
+            .join(' 🖊 '),
+        description: resource.abstract || '',
+        docs_url: '',
+        embed_url: '',
+        page_url: '',
+        resource_id: resource.resource_id,
+        resource_type: resource.resource_type,
+        resource_url: resource.resource_url,
+        date_created: resource.date_created || '',
+        date_last_updated: resource.date_last_updated || '',
+        thumbnail_url: '',
+        title: resource.resource_title,
+        images: [],
+    }));
+
+    // Update each card with custom metadata and images
+    await Promise.all(
+        mapped.map(async (card) => {
+            try {
+                // Fetch custom metadata and images for each presentation
+                const [customMetadata, imageUrls] = await Promise.all([
+                    fetchResourceCustomMetadata(card.resource_id).catch(() => null),
+                    fetchResourceImageUrls(card.resource_id).catch(() => []),
+                ]);
+
+                // Update card with fetched metadata, falling back to existing values if not available
+                if (customMetadata?.pres_path) {
+                    card.embed_url = `https://www.hydroshare.org/resource/${card.resource_id}/data/contents/${customMetadata.pres_path}`;
+                }
+                card.thumbnail_url = customMetadata?.thumbnail_url || card.thumbnail_url;
+                card.page_url = customMetadata?.page_url || card.page_url;
+                card.docs_url = customMetadata?.docs_url || card.docs_url;
+                card.images = imageUrls || [];
+            } catch (err) {
+                console.error(`Error enriching presentation ${card.resource_id}:`, err);
+            }
+        })
+    );
+
+    return mapped;
+}
+
+/**
+ * A component to display an individual event card, which can be clicked to view associated presentations.
+ * @param {*} resource The event resource to display
+ * @param {*} defaultImage The default image to use if the resource doesn't have one
+ * @returns JSX element rendering the event card
+ */
+export function EventCard({ resource, defaultImage }) {
+    const placeholder = isPlaceholder(resource);
+
+    const title = resource?.title || 'Untitled';
+    const description = resource?.description || '';
+    const authors = splitAuthors(resource?.authors);
+
+    const thumbnailUrl = resource?.thumbnail_url || defaultImage;
+    const pageUrl = resource?.page_url;
+    const docsUrl = resource?.docs_url;
+    const resourceUrl = resource?.resource_url;
+    const resourceType = resource?.resource_type;
+    const collectionId = resource?.resource_id;
+
+    const [showModal, setShowModal] = useState(false);
+    const [presentations, setPresentations] = useState(null);
+    const [loadError, setLoadError] = useState(null);
+
+    // Load presentations when modal is opened for the first time
+    useEffect(() => {
+        // Only load if modal is being shown, it's not a placeholder, and we haven't already loaded children
+        if (!showModal || placeholder || presentations !== null) return;
+
+        // Load presentations for the event's collection
+        let cancelled = false;
+        setLoadError(null);
+        loadEventPresentations(collectionId)
+            .then(list => {
+                if (!cancelled) setPresentations(list);
+            })
+            .catch(err => {
+                if (!cancelled) {
+                    console.error(`Error loading event presentations for ${collectionId}:`, err);
+                    setLoadError(err.message || 'Failed to load presentations.');
+                    setPresentations([]);
+                }
+            });
+        return () => { cancelled = true; };
+    }, [showModal, placeholder, collectionId, presentations]);
+
+    // Close modal on Escape key press
+    useEffect(() => {
+        if (!showModal) return;
+        const onKeyDown = (e) => { if (e.key === 'Escape') setShowModal(false); };
+        window.addEventListener('keydown', onKeyDown);
+        return () => window.removeEventListener('keydown', onKeyDown);
+    }, [showModal]);
+
+    // Open modal when title is clicked, but only if not a placeholder
+    const openModal = (e) => {
+        e.preventDefault();
+        if (!placeholder) setShowModal(true);
+    };
+
+    return (
+        <>
+            <article
+                id={collectionId}
+                className="tw-group tw-flex tw-h-full tw-flex-col tw-overflow-hidden tw-rounded-xl tw-border-2 tw-border-slate-400 dark:tw-border-slate-500 tw-bg-slate-100 dark:tw-bg-slate-900 tw-shadow-md hover:tw-shadow-xl hover:tw-border-cyan-500 tw-transition"
+            >
+                <div className="tw-flex tw-flex-1 tw-flex-col tw-gap-4 tw-p-5">
+                    {/* Thumbnail and Title Container */}
+                    <div className="tw-flex tw-items-start tw-gap-4">
+                        {/* Thumbnail */}
+                        <div className="tw-relative tw-shrink-0 tw-w-16 tw-h-16 sm:tw-w-20 sm:tw-h-20 tw-rounded-lg tw-overflow-hidden tw-bg-slate-100 dark:tw-bg-slate-800">
+                            {placeholder ? (
+                                <div className="tw-h-full tw-w-full tw-animate-pulse tw-bg-slate-200 dark:tw-bg-slate-800" />
+                            ) : thumbnailUrl ? (
+                                <img
+                                    src={thumbnailUrl}
+                                    alt={title}
+                                    className="tw-h-full tw-w-full tw-object-fill"
+                                    loading="lazy"
+                                />
+                            ) : (
+                                <div className="tw-flex tw-h-full tw-w-full tw-items-center tw-justify-center tw-text-slate-400 dark:tw-text-slate-500">
+                                    <LuLayers3 size={28} />
+                                </div>
+                            )}
+                        </div>
+                        
+                        {/* Title */}
+                        <div className="tw-min-w-0 tw-flex-1">
+                            {placeholder ? (
+                                <div className="tw-space-y-3">
+                                    <div className="tw-h-5 tw-w-2/3 tw-animate-pulse tw-rounded tw-bg-slate-200 dark:tw-bg-slate-800" />
+                                    <div className="tw-h-4 tw-w-1/3 tw-animate-pulse tw-rounded tw-bg-slate-200 dark:tw-bg-slate-800" />
+                                </div>
+                            ) : (
+                                <h3 className="tw-text-base sm:tw-text-lg tw-font-semibold tw-leading-snug tw-text-slate-900 dark:tw-text-white tw-line-clamp-2">
+                                    <a
+                                        href="#"
+                                        onClick={openModal}
+                                        title={`View presentations for ${title}`}
+                                        className="tw-no-underline tw-text-black hover:tw-text-cyan-700 dark:tw-text-white dark:hover:tw-text-cyan-300 tw-cursor-pointer"
+                                    >
+                                        {title}
+                                    </a>
+                                </h3>
+                            )}
+                        </div>
+                    </div>
+                    
+                    {/* Authors */}
+                    {placeholder ? (
+                        <div className="tw-h-4 tw-w-1/2 tw-animate-pulse tw-rounded tw-bg-slate-200 dark:tw-bg-slate-800" />
+                    ) : (
+                        authors.length > 0 && (
+                            <div className="tw-flex tw-items-start tw-gap-2 tw-text-xs tw-text-slate-600 dark:tw-text-slate-300 tw-whitespace-normal tw-break-words">
+                                <span className="tw-mt-[1px] tw-shrink-0 tw-text-slate-500 dark:tw-text-slate-400" aria-hidden="true">
+                                    <HiOutlineUserGroup size={16} />
+                                </span>
+                                <span>{authors.join(' • ')}</span>
+                            </div>
+                        )
+                    )}
+
+                    {/* Description */}
+                    {placeholder ? (
+                        <div className="tw-space-y-3">
+                            <div className="tw-h-4 tw-w-full tw-animate-pulse tw-rounded tw-bg-slate-200 dark:tw-bg-slate-800" />
+                            <div className="tw-h-4 tw-w-5/6 tw-animate-pulse tw-rounded tw-bg-slate-200 dark:tw-bg-slate-800" />
+                            <div className="tw-h-4 tw-w-3/4 tw-animate-pulse tw-rounded tw-bg-slate-200 dark:tw-bg-slate-800" />
+                        </div>
+                    ) : (
+                        description && (
+                            <p className="tw-text-sm tw-leading-relaxed tw-text-slate-600 dark:tw-text-slate-300 tw-overflow-y-auto tw-max-h-36">
+                                {description}
+                            </p>
+                        )
+                    )}
+                </div>
+                
+                {/* Footer */}
+                <div className="tw-mt-auto tw-flex tw-flex-wrap tw-items-center tw-justify-between tw-gap-3 tw-border-t tw-border-slate-200/70 tw-text-black dark:tw-text-white dark:tw-border-slate-700/70 tw-bg-cyan-400 dark:tw-bg-slate-800 tw-px-5 tw-py-3">
+                    {/* Resource Type */}
+                    <div className="tw-flex tw-flex-wrap tw-gap-2">
+                        {!placeholder && <StatTag>{resourceType || 'Event'}</StatTag>}
+                    </div>
+                    
+                    {/* Action Link Buttons */}
+                    <div className="tw-flex tw-items-center tw-gap-2">
+                        <ActionLink href={pageUrl} title="Website">
+                            <LiaExternalLinkSquareAltSolid size={18} />
+                        </ActionLink>
+                        <ActionLink href={docsUrl} title="Learning / Docs">
+                            <FaGraduationCap size={16} />
+                        </ActionLink>
+                        <ActionLink href={resourceUrl} title="HydroShare Resource">
+                            <HiOutlineGlobeAlt size={18} />
+                        </ActionLink>
+                    </div>
+                </div>
+            </article>
+            
+            {/* Event Presentations Modal */}
+            <EventPresentationsModal
+                show={showModal}
+                onClose={() => setShowModal(false)}
+                title={title}
+                presentations={presentations}
+                loadError={loadError}
+            />
+        </>
+    );
+}
+
+/**
+ * Component to display a grid of event cards.
+ * @param {Array} resources List of event resources to display
+ * @param {string} defaultImage URL of default image to use if a resource doesn't have one
+ * @returns JSX element rendering the grid of event cards
+ */
+export default function HydroShareEventCards({ resources, defaultImage }) {
+    return (
+        <div className="tw-grid tw-grid-cols-1 lg:tw-grid-cols-2 2xl:tw-grid-cols-3 tw-gap-6">
+            {resources.map(resource => (
+                <EventCard
+                    key={resource.resource_id}
+                    resource={resource}
+                    defaultImage={defaultImage}
+                />
+            ))}
+        </div>
+    );
+}

--- a/src/components/HydroShareEventCards/styles.module.css
+++ b/src/components/HydroShareEventCards/styles.module.css
@@ -1,0 +1,4 @@
+.modalBelowNavbar {
+  top: var(--ifm-navbar-height);
+  height: calc(100vh - var(--ifm-navbar-height));
+}

--- a/src/components/HydroShareResourcesSelector/index.js
+++ b/src/components/HydroShareResourcesSelector/index.js
@@ -56,6 +56,7 @@ export default function HydroShareResourcesSelector({
   defaultImage,
   variant = 'legacy',
   onResultsChange,
+  cardsComponent: CardsComponent = HydroShareResourcesCards,
 }) {
   const { colorMode } = useColorMode(); // Get the current theme
   const PLACEHOLDER_ITEMS = 10;
@@ -313,6 +314,7 @@ export default function HydroShareResourcesSelector({
   else if (keyword.includes('module')) resultLabel = 'Courses';
   else if (keyword.includes('data')) resultLabel = 'Datasets';
   else if (keyword.includes('presentation')) resultLabel = 'Presentations';
+  else if (keyword.includes('event')) resultLabel = 'Events';
 
 
   /* ---------------- render ---------------- */
@@ -419,7 +421,7 @@ export default function HydroShareResourcesSelector({
           {view === 'grid' ? (
             <HydroShareResourcesTiles resources={resources} defaultImage={defaultImage} />
           ) : (
-            <HydroShareResourcesCards resources={resources} defaultImage={defaultImage} />
+            <CardsComponent resources={resources} defaultImage={defaultImage} />
           )}
 
           {!loading && nonPlaceholderResources.length === 0 && (

--- a/src/components/HydroShareResourcesSelector/index.js
+++ b/src/components/HydroShareResourcesSelector/index.js
@@ -75,6 +75,11 @@ export default function HydroShareResourcesSelector({
   }));
 
   const hs_icon = colorMode === 'dark' ? DatasetDarkIcon : DatasetLightIcon;
+  const hsIconRef = useRef(hs_icon);
+
+  useEffect(() => {
+    hsIconRef.current = hs_icon;
+  }, [hs_icon]);
   
   // State
   const [resources, setResources] = useState(initialPlaceholders);
@@ -204,7 +209,7 @@ export default function HydroShareResourcesSelector({
             if (customMetadata?.pres_path) embedUrl = `https://www.hydroshare.org/resource/${res.resource_id}/data/contents/${customMetadata.pres_path}`;
             const updatedResource = {
               ...res,
-              thumbnail_url: customMetadata?.thumbnail_url || hs_icon,
+              thumbnail_url: customMetadata?.thumbnail_url || hsIconRef.current,
               page_url: customMetadata?.page_url || "",
               docs_url: customMetadata?.docs_url || "",
               embed_url: embedUrl,
@@ -227,7 +232,7 @@ export default function HydroShareResourcesSelector({
         fetching.current = false;
       }
     },
-    [keyword, filterSearch, sortDirection, sortType, hs_icon]
+    [keyword, filterSearch, sortDirection, sortType]
   );
 
 

--- a/src/components/HydroShareResourcesSelector/index.js
+++ b/src/components/HydroShareResourcesSelector/index.js
@@ -6,9 +6,6 @@ import HydroShareResourcesTiles from "@site/src/components/HydroShareResourcesTi
 import HydroShareResourcesRows from "@site/src/components/HydroShareResourcesRows";
 import HydroShareResourcesCards from "@site/src/components/HydroShareResourcesCards";
 import { fetchResourcesBySearch, fetchResourceCustomMetadata, getCommunityResources } from "@site/src/components/HydroShareImporter";
-import { useColorMode } from "@docusaurus/theme-common"; // Hook to detect theme
-import DatasetLightIcon from '@site/static/img/cards/datasets_logo_light.png';
-import DatasetDarkIcon from '@site/static/img/cards/datasets_logo_dark.png';
 import {
   HiOutlineSortDescending,
   HiOutlineSortAscending,
@@ -58,7 +55,6 @@ export default function HydroShareResourcesSelector({
   onResultsChange,
   cardsComponent: CardsComponent = HydroShareResourcesCards,
 }) {
-  const { colorMode } = useColorMode(); // Get the current theme
   const PLACEHOLDER_ITEMS = 10;
 
   // Initialize with placeholder objects so that the component renders immediately.
@@ -75,13 +71,6 @@ export default function HydroShareResourcesSelector({
     embed_url: "",
   }));
 
-  const hs_icon = colorMode === 'dark' ? DatasetDarkIcon : DatasetLightIcon;
-  const hsIconRef = useRef(hs_icon);
-
-  useEffect(() => {
-    hsIconRef.current = hs_icon;
-  }, [hs_icon]);
-  
   // State
   const [resources, setResources] = useState(initialPlaceholders);
   const [error, setError] = useState(null);
@@ -210,7 +199,7 @@ export default function HydroShareResourcesSelector({
             if (customMetadata?.pres_path) embedUrl = `https://www.hydroshare.org/resource/${res.resource_id}/data/contents/${customMetadata.pres_path}`;
             const updatedResource = {
               ...res,
-              thumbnail_url: customMetadata?.thumbnail_url || hsIconRef.current,
+              thumbnail_url: customMetadata?.thumbnail_url || "",
               page_url: customMetadata?.page_url || "",
               docs_url: customMetadata?.docs_url || "",
               embed_url: embedUrl,

--- a/src/pages/events/index.js
+++ b/src/pages/events/index.js
@@ -63,10 +63,7 @@ function EventsPageContent({ contributeUrl, docsUrl }) {
           <Header
             title="Events"
             tagline="Conferences, workshops, and meetings where CIROH and NOAA hydrologic research is shared. Click an event to browse its presentations."
-            buttons={[
-              { label: "Add your Presentation", href: contributeUrl, primary: true },
-              { label: "Browse Documentation", href: docsUrl }
-            ]}
+            buttons={[]}
           />
         </div>
       </section>

--- a/src/pages/events/index.js
+++ b/src/pages/events/index.js
@@ -10,6 +10,8 @@ import Header from "@site/src/components/Header";
 import { useColorMode } from '@docusaurus/theme-common';
 import StatsBar from "@site/src/components/StatsBar";
 import { getResourceStats } from "@site/src/utils/resourceStats";
+import DatasetLightIcon from '@site/static/img/cards/datasets_logo_light.png';
+import DatasetDarkIcon from '@site/static/img/cards/datasets_logo_dark.png';
 
 const items = [
   {
@@ -38,7 +40,7 @@ export default function EventsPage() {
 function EventsPageContent({ contributeUrl, docsUrl }) {
   const { colorMode } = useColorMode();
   const isDarkTheme = colorMode === 'dark';
-  const defaultImage = 'https://ciroh-portal-static-data.s3.us-east-1.amazonaws.com/presentation_placeholder.png';
+  const defaultImage = isDarkTheme ? DatasetDarkIcon : DatasetLightIcon;
 
   const [events, setEvents] = useState([]);
   const [statsLoading, setStatsLoading] = useState(true);

--- a/src/pages/events/index.js
+++ b/src/pages/events/index.js
@@ -1,0 +1,98 @@
+import React, { useCallback, useMemo, useState } from "react";
+import { ConstellationCanvas } from '@site/src/components/ConstellationCanvas';
+import Layout from '@theme/Layout';
+import TechBox from "@site/src/components/TechBox";
+import HydroShareResourcesSelector from "@site/src/components/HydroShareResourcesSelector";
+import HydroShareEventCards from "@site/src/components/HydroShareEventCards";
+import HydroShareLogo from '@site/static/img/logos/hydroshare-white.png';
+import useBaseUrl from '@docusaurus/useBaseUrl';
+import Header from "@site/src/components/Header";
+import { useColorMode } from '@docusaurus/theme-common';
+import StatsBar from "@site/src/components/StatsBar";
+import { getResourceStats } from "@site/src/utils/resourceStats";
+
+const items = [
+  {
+    lightIcon: HydroShareLogo,
+    darkIcon: HydroShareLogo,
+    alt: 'HydroShare',
+    name: 'HydroShare',
+    href: 'https://hydroshare.org/',
+  },
+];
+
+export default function EventsPage() {
+  const contributeUrl = useBaseUrl('/contribute?current-contribution=presentations');
+  const docsUrl = useBaseUrl('/docs/products/intro');
+
+  return (
+    <Layout title="Events" description="CIROH Events">
+      <EventsPageContent
+        contributeUrl={contributeUrl}
+        docsUrl={docsUrl}
+      />
+    </Layout>
+  );
+}
+
+function EventsPageContent({ contributeUrl, docsUrl }) {
+  const { colorMode } = useColorMode();
+  const isDarkTheme = colorMode === 'dark';
+  const defaultImage = 'https://ciroh-portal-static-data.s3.us-east-1.amazonaws.com/presentation_placeholder.png';
+
+  const [events, setEvents] = useState([]);
+  const [statsLoading, setStatsLoading] = useState(true);
+
+  const onResultsChange = useCallback((results, meta) => {
+    setEvents(results);
+    setStatsLoading(Boolean(meta?.loading));
+  }, []);
+
+  const stats = useMemo(() => getResourceStats(events), [events]);
+
+  return (
+    <>
+      {/* Hero */}
+      <section className="tw-relative tw-z-20 tw-overflow-hidden tw-pb-8">
+        <div className="tw-absolute tw-inset-0 tw-pointer-events-none tw-overflow-hidden" style={{ zIndex: 0 }}>
+          <ConstellationCanvas isDarkTheme={isDarkTheme} />
+        </div>
+        <div className="margin-top--lg">
+          <Header
+            title="Events"
+            tagline="Conferences, workshops, and meetings where CIROH and NOAA hydrologic research is shared. Click an event to browse its presentations."
+            buttons={[
+              { label: "Add your Presentation", href: contributeUrl, primary: true },
+              { label: "Browse Documentation", href: docsUrl }
+            ]}
+          />
+        </div>
+      </section>
+
+      {/* Stats */}
+      <StatsBar
+        loading={statsLoading}
+        items={[
+          { label: 'Total Events', value: stats.total },
+          { label: 'Categories', value: stats.categories },
+          { label: 'Contributors', value: stats.contributors },
+          { label: 'Latest Update', value: stats.lastUpdated },
+        ]}
+      />
+
+      <main className="tw-relative tw-z-20">
+        <HydroShareResourcesSelector
+          keyword="ciroh_hub_event"
+          defaultImage={defaultImage}
+          variant="modern"
+          cardsComponent={HydroShareEventCards}
+          onResultsChange={onResultsChange}
+        />
+
+        <div className="tw-pb-16">
+          <TechBox items={items} type={"Events"} />
+        </div>
+      </main>
+    </>
+  );
+}

--- a/src/pages/events/styles.module.css
+++ b/src/pages/events/styles.module.css
@@ -1,0 +1,3 @@
+body{
+  overflow-x: hidden;
+}

--- a/src/pages/events/styles.module.css
+++ b/src/pages/events/styles.module.css
@@ -1,3 +1,0 @@
-body{
-  overflow-x: hidden;
-}


### PR DESCRIPTION
Add an Events page which uses the `HydroShareResourcesSelector` component to display HydroShare resources that have the tag `ciroh_hub_event`.

This allows us to "group" presentations by the event they were given at, while at the same time using existing functionality.

## Additions

- An events page which displays HydroShare resources tagged with `ciroh_hub_event`
- The `ModalEventPresentations` component which is used to display an event on the events page.
- The `ModalEventPresentations` component which displays an event's presentations

## Changes

- Update the `HydroShareResourcesSelector` with a `cardsComponent` prop for custom card rendering
- Decouple card icon from resource fetch dependencies to avoid page refresh when switching website theme (light/dark mode)

## Screenshots

<img width="1902" height="892" alt="image" src="https://github.com/user-attachments/assets/f6605b75-b8ae-4d71-878a-ee49c9f840e3" />

.

<img width="1919" height="911" alt="image" src="https://github.com/user-attachments/assets/0367e2cc-8b60-440c-a39b-507877a1f150" />


## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
