### PR TITLE
Update custom image docs

### DIFF
--- a/docs/services/cloudservices/2i2c/available-images.mdx
+++ b/docs/services/cloudservices/2i2c/available-images.mdx
@@ -15,17 +15,9 @@ tags: [CIROH, Services, Cloud Services, JupyterHub, 2i2c, Google Cloud, Educatio
 
 Server image configurations are options for what software environment you want your Jupyter Notebook server to run in.
 
-:::note
-This list is currently non-comprehensive and will be expanded soon.  
-For a complete listing of available server images, see [the branches of **awi-ciroh-image** on GitHub](https://github.com/CIROH-UA/awi-ciroh-image/branches).
-:::
+A full listing of these images [can be found on the GitHub wiki]("https://github.com/CIROH-UA/awi-ciroh-image/wiki/2i2c-image-list").
 
-## Pangeo Notebook base image
-
-This configuration has a general set of pre-installed libraries and tools commonly used in geoscience for tasks such as data analysis and mapping. It allows users to run workflows directly from JupyterHub without the need to install software or manage dependencies. This base image serves as a starting point; users can run it as-is for general analysis or build on it with additional packages tailored to hydrology, climate science, and beyond.
-
-## CIROH Community NextGen Hub
-
-This configuration has the NextGen Framework and its preprocessor tools pre-installed, allowing for them to be run from JupyterHub without users needing to install software or configure dependencies.
-
-To get started with this image, please see the extended tutorial in the Documentation section: "[NextGen on CIROH-2i2c JupyterHub](/docs/products/ngiab/distributions/nextgen-2i2c/)"
+{/* 
+    Note that as of June 2026, the GitHub REST API does not support markdown output of wiki pages.
+    If and when this feature is finally provided, the "GitHubWikiPage" component should provide full support.
+*/}

--- a/docs/services/cloudservices/2i2c/available-images.mdx
+++ b/docs/services/cloudservices/2i2c/available-images.mdx
@@ -1,6 +1,6 @@
 ---
-sidebar_position: 21
-title: "Server Image Configurations"
+sidebar_position: 22
+title: "List of Available Images"
 description: "Explore CIROH's available image configurations."
 tags: [CIROH, Services, Cloud Services, JupyterHub, 2i2c, Google Cloud, Education]
 ---

--- a/docs/services/cloudservices/2i2c/custom-images.mdx
+++ b/docs/services/cloudservices/2i2c/custom-images.mdx
@@ -1,6 +1,6 @@
 ---
-sidebar_position: 22
-title: "Request Custom Images"
+sidebar_position: 21
+title: "Custom Images"
 description: "Request JupyterHub server images tailored to your needs."
 tags: [CIROH, Services, Cloud Services, JupyterHub, 2i2c, Google Cloud, Education]
 ---
@@ -13,30 +13,9 @@ tags: [CIROH, Services, Cloud Services, JupyterHub, 2i2c, Google Cloud, Educatio
     30-39: Miscellaneous/Troubleshooting
 */}
 
-import Link from '@docusaurus/Link'
+import GitHubReadme from '@site/src/components/GitHubHandling/GitHubReadme';
 
-# A Step-by-Step Guide: Requesting custom images
-If you have a request for creating custom images, then please follow these instructions.
-### 1. Create an environment.yml file:
-- Open your terminal or command prompt. Make sure you have conda installed and activated in the environment that contains the packages you want to use for creating custom images. Learn more [here](https://conda.io/projects/conda/en/latest/user-guide/getting-started.html).
-
-- Run the following command, replacing **ENVNAME** with the actual name of your environment.
-
-```bash
-conda env export -n ENVNAME > environment.yml
-```
-
-### 2. Open a GitHub Ticket
-
-- Open a ticket in the [CIROH image repository](https://github.com/CIROH-UA/awi-ciroh-image/issues).
-- Describe the custom image or software changes you need.
-- If relevant, attach or paste the `environment.yml` file you created in step 1.
-
-<Link class="button button--active button--primary" to="https://github.com/CIROH-UA/awi-ciroh-image/issues">Open a Custom Image Ticket</Link>
-
-### 3. Follow up with the CIROH team if needed
-
-- If the team has questions about your request, they will follow up on the GitHub ticket.
+<GitHubReadme username="ciroh-ua" repo="awi-ciroh-image" />
 
 
  

--- a/docs/services/cloudservices/2i2c/index.mdx
+++ b/docs/services/cloudservices/2i2c/index.mdx
@@ -17,6 +17,18 @@ CIROH, in collaboration with 2i2c, offers a dedicated JupyterHub environment on 
 <img src={useBaseUrl("/img/services/2i2c/2i2c.png")} alt="2i2c Image" style={{'width':'80%', 'height':'50%'}}/>
 </p>
 
+## CIROH-2i2c JupyterHub Environments
+
+Click on the buttons below to access the CIROH-2i2c JupyterHub environments.
+> *Note that the workshop environment is only active for the duration of the conferences and programs it supports.*
+<br/>
+
+<Link class="button button--active button--primary" style={{'margin-bottom':'1.3rem', 'margin-right':'1.4rem'}}  to="https://ciroh.awi.2i2c.cloud/hub/login"> CIROH Production JupyterHub</Link>
+
+<Link class="button button--active button--primary" style={{'margin-bottom':'1.3rem', 'margin-right':'1.4rem'}} to="https://staging.ciroh.awi.2i2c.cloud/hub/login"> CIROH Staging JupyterHub</Link>
+
+{/* <Link class="button button--active button--primary" style={{'margin-bottom':'1.3rem', 'margin-right':'1.4rem'}} to="https://workshop.ciroh.awi.2i2c.cloud/hub/login"> CIROH Workshop JupyterHub</Link> */}
+
 ## Video Tutorial
 
 Watch this video to find out how to access CIROH-2i2c Jupyterhub and how to launch and use CIROH-2i2c Jupyterhub with HydroShare:
@@ -25,6 +37,12 @@ Watch this video to find out how to access CIROH-2i2c Jupyterhub and how to laun
   <iframe width="791" height="421" src="https://www.youtube.com/embed/DnbxhLdb6TM" title="CIROH-2i2c Jupyterhub" style={{border: 'none'}} allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 </div>
 
+import VideoPlayer from '/src/components/VideoPlayer.js';
+
+<div class="indent-wrapper">
+  <p><b>Please remember to stop the server when you're not actively using it.</b></p>
+  <VideoPlayer url="https://youtu.be/kcw6HCNKylU"/>
+</div>
 
 ## Benefits of CIROH-2i2c JupyterHub:
 
@@ -55,34 +73,9 @@ If your software is not listed there, please open a ticket in the [CIROH image r
 
 <Link class="button button--active button--primary" to="https://github.com/CIROH-UA/awi-ciroh-image/issues"> Open a Custom Image Ticket</Link>
 
-
 ---
 
-## CIROH-2i2c JupyterHub Environments
-
-Click on the buttons below to access the CIROH-2i2c JupyterHub environments.
-> *Note that the workshop environment is only active for the duration of the conferences and programs it supports.*
-<br/>
-
-<Link class="button button--active button--primary" style={{'margin-bottom':'1.3rem', 'margin-right':'1.4rem'}}  to="https://ciroh.awi.2i2c.cloud/hub/login"> CIROH Production JupyterHub</Link>
-
-<Link class="button button--active button--primary" style={{'margin-bottom':'1.3rem', 'margin-right':'1.4rem'}} to="https://staging.ciroh.awi.2i2c.cloud/hub/login"> CIROH Staging JupyterHub</Link>
-
-<Link class="button button--active button--primary" style={{'margin-bottom':'1.3rem', 'margin-right':'1.4rem'}} to="https://workshop.ciroh.awi.2i2c.cloud/hub/login"> CIROH Workshop JupyterHub</Link>
-
----
-
-import VideoPlayer from '/src/components/VideoPlayer.js';
-
-<div class="indent-wrapper">
-  <p><b>Please remember to stop the server when you're not actively using it.</b></p>
-  <VideoPlayer url="https://youtu.be/kcw6HCNKylU"/>
-</div>
-_____
-
-<p align="center">
-<img src={useBaseUrl("/img/services/2i2c/2i2c-1.png")} alt="2i2c Image" style={{'width':'80%', 'height':'50%'}}/>
-</p>
+## Specifications
 
 ### Server Options
 - Small - 5GB RAM, 2 CPUs
@@ -99,11 +92,15 @@ The per user storage quota is currently set to 250 GB.
 
 ### Software currently deployed on CIROH-2i2c JupyterHub
 
-Please refer to the [Dockerfile](https://github.com/CIROH-UA/awi-ciroh-image/blob/main/Dockerfile) for the list of software currently deployed on CIROH-2i2c JupyterHub.
+Please refer to the [list of images](/services/cloudservices/2i2c/available-images) for summaries of software environments that you can deploy on CIROH-2i2c JupyterHub.
 
 ### Cost of Use
 
 CIROH 2i2c JupyterHub is free to use for consortium members. Its cost is covered by CIROH Infrastructure project funds.
+
+<p align="center">
+<img src={useBaseUrl("/img/services/2i2c/2i2c-1.png")} alt="2i2c Image" style={{'width':'80%', 'height':'50%'}}/>
+</p>
 
 ---
 

--- a/docs/services/cloudservices/2i2c/index.mdx
+++ b/docs/services/cloudservices/2i2c/index.mdx
@@ -68,7 +68,7 @@ Click on the buttons below to access the CIROH-2i2c JupyterHub environments.
 
 <Link class="button button--active button--primary" style={{'margin-bottom':'1.3rem', 'margin-right':'1.4rem'}} to="https://staging.ciroh.awi.2i2c.cloud/hub/login"> CIROH Staging JupyterHub</Link>
 
-{/* <Link class="button button--active button--primary" style={{'margin-bottom':'1.3rem', 'margin-right':'1.4rem'}} to="https://workshop.ciroh.awi.2i2c.cloud/hub/login"> CIROH Workshop JupyterHub</Link> */}
+<Link class="button button--active button--primary" style={{'margin-bottom':'1.3rem', 'margin-right':'1.4rem'}} to="https://workshop.ciroh.awi.2i2c.cloud/hub/login"> CIROH Workshop JupyterHub</Link>
 
 ---
 

--- a/src/components/GitHubHandling/GitHubMarkdown.js
+++ b/src/components/GitHubHandling/GitHubMarkdown.js
@@ -1,0 +1,114 @@
+import React, { useEffect, useState } from 'react';
+
+function GitHubMarkdown({ apiUrl, srcUrl, cwdUrl, trimTitle = 'false' }) {
+    const [markdownContent, setMarkdownContent] = useState('');
+
+    const applyHtmlTransformations = (html) => {
+        const parser = new DOMParser();
+        var doc = parser.parseFromString(html, 'text/html');
+
+        // Transformations
+        doc = unshellReadme(doc);
+        doc = convertRelativePaths(doc);
+        if (trimTitle === 'true') doc = trimFirstLine(doc); // Yes, this feels silly, but having it line up semantically with the JSX matters
+
+        return doc.body.innerHTML;
+    };
+
+    // Converts GitHub paths to DocuHub paths, where appropriate.
+    // References that jump to other parts of the page are
+    // non-functional in DocuHub, so they are discarded.
+    const convertRelativePaths = (doc) => {
+        // Convert image sources
+        doc.querySelectorAll('img[src]').forEach(img => {
+            const src = img.getAttribute('src');
+            if (!src.startsWith('http')) {
+                const relativePath = src.replace(/^\//, '');
+                img.src = `${cwdUrl}${relativePath}`;
+            }
+        });
+
+        // Convert anchor href attributes
+        doc.querySelectorAll('a[href]').forEach(anchor => {
+            const href = anchor.getAttribute('href');
+            if (href && !href.startsWith('http') && !href.startsWith('#')) {
+                const relativePath = href.replace(/^\//, '');
+                anchor.href = `${cwdUrl}${relativePath}`;
+            }
+            else if (href && href.startsWith('#')) {
+                var span = doc.createElement("span");
+                span.innerHTML = anchor.innerHTML;
+                anchor.replaceWith(span);
+            }
+        });
+
+        return doc;
+    }
+
+    // Removes much of the cruft from a GitHub README.
+    const unshellReadme = (doc) => {
+        const content = doc.querySelector("article").childNodes;
+        var newContent = [];
+
+        for (var i = 0; i < content.length; i++) {
+            const node = content[i];
+            if (node.className === "markdown-heading") {
+                // The second element is a relative link that
+                // does not work within our renderer,
+                // so we simply discard it.
+                newContent.push(node.childNodes[0]);
+            }
+            else newContent.push(node);
+        }
+        
+        doc.body.innerHTML='';
+        doc.body.replaceChildren(...newContent);
+        return doc;
+    }
+
+    // Trims the first element of the HTML body.
+    const trimFirstLine = (doc) => {
+        if (doc.body.firstElementChild.tagName === "H1") {
+            doc.body.removeChild(doc.body.firstElementChild);
+        }
+        return doc;
+    }
+
+    useEffect(() => {
+        fetch(apiUrl, {
+            headers: {
+                Accept: 'application/vnd.github.v3.html',
+            },
+        })
+            .then(response => {
+                if (!response.ok) {
+                    throw new Error('Failed to fetch README');
+                }
+                return response.text();
+            })
+            .then(html => {
+                // Apply transformations to html
+                var processedHtml = applyHtmlTransformations(html);
+
+                // Define the note markdown as a string
+                const noteHtml = `
+                <blockquote style='padding:20px;font-size:1.1rem;'>
+                    <strong>NOTE</strong><br>
+                    Below content is rendered from <a href='${srcUrl}'>${srcUrl}</a>.
+                </blockquote>
+                `;
+
+                // Prepend the note markdown to the processed README content
+                const combinedHtml = noteHtml + processedHtml;
+
+                // Update the state with the combined content
+                setMarkdownContent(combinedHtml);
+            })
+            .catch(err => console.error('Error fetching README:', err));
+    }, [apiUrl, srcUrl, cwdUrl, trimTitle]);
+
+    // Render the HTML content
+    return <div dangerouslySetInnerHTML={{ __html: markdownContent }} />;
+}
+
+export default GitHubMarkdown;

--- a/src/components/GitHubHandling/GitHubReadme.js
+++ b/src/components/GitHubHandling/GitHubReadme.js
@@ -1,132 +1,28 @@
 import React, { useEffect, useState } from 'react';
+import GitHubMarkdown from './GitHubMarkdown'
 
 function GitHubReadme({ repo, username, subfolder = '', readmeFileName = '', trimTitle = 'false' }) {
-    const [readmeContent, setReadmeContent] = useState('');
-
-    const applyHtmlTransformations = (html, baseUrl) => {
-        const parser = new DOMParser();
-        var doc = parser.parseFromString(html, 'text/html');
-
-        // Transformations
-        doc = unshellReadme(doc);
-        doc = convertRelativePaths(doc);
-        if (trimTitle === 'true') doc = trimFirstLine(doc); // Yes, this feels silly, but having it line up semantically with the JSX matters
-
-        return doc.body.innerHTML;
-    };
-
-    // Converts GitHub paths to DocuHub paths, where appropriate.
-    // References that jump to other parts of the page are
-    // non-functional in DocuHub, so they are discarded.
-    const convertRelativePaths = (doc) => {
-        // Convert image sources
-        doc.querySelectorAll('img[src]').forEach(img => {
-            const src = img.getAttribute('src');
-            if (!src.startsWith('http')) {
-                const relativePath = src.replace(/^\//, '');
-                img.src = `https://github.com/${username}/${repo}/raw/main/${subfolder ? subfolder + '/' : ''}${relativePath}`;
-            }
-        });
-
-        // Convert anchor href attributes
-        doc.querySelectorAll('a[href]').forEach(anchor => {
-            const href = anchor.getAttribute('href');
-            if (href && !href.startsWith('http') && !href.startsWith('#')) {
-                const relativePath = href.replace(/^\//, '');
-                anchor.href = `https://github.com/${username}/${repo}/blob/main/${subfolder ? subfolder + '/' : ''}${relativePath}`;
-            }
-            else if (href && href.startsWith('#')) {
-                var span = doc.createElement("span");
-                span.innerHTML = anchor.innerHTML;
-                anchor.replaceWith(span);
-            }
-        });
-
-        return doc;
+    // Construct the GitHub API URL to fetch the README as HTML
+    let slug = '';
+    if (subfolder !== '') {
+        if (readmeFileName !== '') 
+            slug = `${subfolder}/${readmeFileName}`;
+        else
+            slug = `${subfolder}/README.md`;
+    } 
+    else {
+        if (readmeFileName !== '') 
+            slug = `${readmeFileName}`;
+        else
+            slug = `README.md`;
     }
 
-    // Removes much of the cruft from a GitHub README.
-    const unshellReadme = (doc) => {
-        const content = doc.querySelector("article").childNodes;
-        var newContent = [];
-
-        for (var i = 0; i < content.length; i++) {
-            const node = content[i];
-            if (node.className === "markdown-heading") {
-                // The second element is a relative link that
-                // does not work within our renderer,
-                // so we simply discard it.
-                newContent.push(node.childNodes[0]);
-            }
-            else newContent.push(node);
-        }
-        
-        doc.body.innerHTML='';
-        doc.body.replaceChildren(...newContent);
-        return doc;
-    }
-
-    // Trims the first element of the HTML body.
-    const trimFirstLine = (doc) => {
-        if (doc.body.firstElementChild.tagName === "H1") {
-            doc.body.removeChild(doc.body.firstElementChild);
-        }
-        return doc;
-    }
-
-    useEffect(() => {
-        // Construct the GitHub API URL to fetch the README as HTML
-        let slug = '';
-        if (subfolder !== '') {
-            if (readmeFileName !== '') 
-                slug = `${subfolder}/${readmeFileName}`;
-            else
-                slug = `${subfolder}/README.md`;
-        } 
-        else {
-            if (readmeFileName !== '') 
-                slug = `${readmeFileName}`;
-            else
-                slug = `README.md`;
-        }
-
-        const apiUrl = `https://api.github.com/repos/${username}/${repo}/contents/${slug}?ref=main`;
-        const srcUrl = `https://github.com/${username}/${repo}/blob/main/${slug}`;
-
-        fetch(apiUrl, {
-            headers: {
-                Accept: 'application/vnd.github.v3.html',
-            },
-        })
-            .then(response => {
-                if (!response.ok) {
-                    throw new Error('Failed to fetch README');
-                }
-                return response.text();
-            })
-            .then(html => {
-                // Apply transformations to html
-                var processedHtml = applyHtmlTransformations(html);
-
-                // Define the note markdown as a string
-                const noteHtml = `
-                <blockquote style='padding:20px;font-size:1.1rem;'>
-                    <strong>NOTE</strong><br>
-                    Below content is rendered from <a href='${srcUrl}'>${srcUrl}</a>.
-                </blockquote>
-                `;
-
-                // Prepend the note markdown to the processed README content
-                const combinedHtml = noteHtml + processedHtml;
-
-                // Update the state with the combined content
-                setReadmeContent(combinedHtml);
-            })
-            .catch(err => console.error('Error fetching README:', err));
-    }, [repo, username, subfolder, readmeFileName]);
+    const apiUrl = `https://api.github.com/repos/${username}/${repo}/contents/${slug}?ref=main`;
+    const srcUrl = `https://github.com/${username}/${repo}/blob/main/${slug}`;
+    const cwdUrl = `https://github.com/${username}/${repo}/raw/main/${subfolder ? subfolder + '/' : ''}`;
 
     // Render the HTML content
-    return <div dangerouslySetInnerHTML={{ __html: readmeContent }} />;
+    return <GitHubMarkdown apiUrl={apiUrl} srcUrl={srcUrl} cwdUrl={cwdUrl} trimTitle={trimTitle} />;
 }
 
 export default GitHubReadme;

--- a/src/components/GitHubHandling/GitHubWikiPage.js
+++ b/src/components/GitHubHandling/GitHubWikiPage.js
@@ -1,0 +1,21 @@
+import React, { useEffect, useState } from 'react';
+import GitHubMarkdown from './GitHubMarkdown'
+
+// Unfortunately, a feature request for this appears to have spent two years
+// untouched, so this is not currently something we can do.
+// It's highly desirable as a feature, though, so I've left the stub here in the meantime.
+// 
+// - Nia Minor, 06/12/2026
+
+function GitHubWikiPage({ repo, username, path = 'home', trimTitle = 'false' }) {
+    // Construct the GitHub API URL to fetch the wiki page as HTML
+    const apiUrl = `api-url-here`;
+    const srcUrl = `https://github.com/${username}/${repo}/wiki/${path}`;
+    const cwdUrl = `https://github.com/${username}/${repo}/`; // This appears to be the documented behavior for image referencing (?)
+
+    // Render the HTML content
+    //return <GitHubMarkdown apiUrl={apiUrl} srcUrl={srcUrl} cwdUrl={cwdUrl} trimTitle={trimTitle} />;
+    return "Unsupported pending a GitHub API update. See https://github.com/orgs/community/discussions/102891#discussioncomment-8340473";
+}
+
+export default GitHubWikiPage;


### PR DESCRIPTION
- Restructures the coverage of custom 2i2c images. The first page now mirrors [the (rewritten) README](https://github.com/CIROH-UA/awi-ciroh-image/blob/main/README.md) with contribution and request instructions, while the list of available images has been moved to the second page.
- Restructures 2i2c landing page for navigability.

Closes #127.