### PR TITLE
refactor: Use hydroshare's public search API endpoint

### DIFF
--- a/src/api/hydroshareAPI.js
+++ b/src/api/hydroshareAPI.js
@@ -8,7 +8,7 @@
  * Adjust or add query parameters (e.g., page, count) as needed.
  */
 
-const HS_SEARCH_ENDPOINT = "https://www.hydroshare.org/hsapi/discovery-atlas/search"
+const HS_SEARCH_ENDPOINT = "https://www.hydroshare.org/hsapi/discovery-atlas/search";
 const HS_SEARCH_PAGE_SIZE = 40;
 const HS_SORT_MAP = {
   "modified": "lastModified",
@@ -356,7 +356,6 @@ export {
   fetchResourcesBySearch,
   fetchSearchResourcesCore,
   HS_SEARCH_PAGE_SIZE,
-  getCommunityResources, 
   fetchResourceCustomMetadata, 
   joinExtraResources, 
   fetchRawCuratedResources,

--- a/src/api/hydroshareAPI.js
+++ b/src/api/hydroshareAPI.js
@@ -8,6 +8,15 @@
  * Adjust or add query parameters (e.g., page, count) as needed.
  */
 
+const HS_SEARCH_ENDPOINT = "https://www.hydroshare.org/hsapi/discovery-atlas/search"
+const HS_SEARCH_PAGE_SIZE = 40;
+const HS_SORT_MAP = {
+  "modified": "lastModified",
+  "created": "dateCreated",
+  "title": "name",
+  "author": "creatorName",
+};
+
 /**
  * Convert author name from "First Middle Last" to "Last, First Middle"
  * @param {string} author - The author name in "First Middle Last" format
@@ -30,6 +39,53 @@ function convertAuthorToLastFirst(author) {
   }
 
   return author;
+}
+
+async function fetchJson(url, errorContext = "resources") {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Error fetching ${errorContext} (status: ${response.status})`);
+  }
+  return response.json();
+}
+
+function buildSearchUrl(keyword, searchText, ascending, sortBy, author, paginationToken, pageSize = HS_SEARCH_PAGE_SIZE) {
+  const paramsObj = {
+    pageSize: pageSize.toString(),
+    term: searchText ? searchText.trim() : undefined,
+    keyword: keyword ? keyword : undefined,
+    order: ascending ? "asc" : "desc",
+    sortBy: sortBy ? HS_SORT_MAP[sortBy.toLowerCase()] : undefined,
+    creatorName: author ? convertAuthorToLastFirst(author) : undefined,
+    paginationToken: paginationToken ? paginationToken : undefined,
+  };
+  const params = new URLSearchParams(Object.fromEntries(Object.entries(paramsObj).filter(([, v]) => v !== undefined)));
+  return `${HS_SEARCH_ENDPOINT}?${params.toString()}`;
+}
+
+function mapSearchResource(item) {
+  const doc = item.document?.[0] ?? {};
+  return {
+    resource_id: doc.url?.split('/').pop() ?? item._id,
+    resource_title: item.name ?? null,
+    authors: (item.creator ?? []).map(c => c.name),
+    resource_type: doc.additionalType ?? null,
+    resource_url: doc.url ?? null,
+    abstract: item.description ?? null,
+    date_created: doc.dateCreated ?? null,
+    date_last_updated: doc.dateModified ?? null,
+  };
+}
+
+async function fetchSearchResourcesCore({ keyword, searchText, ascending = false, sortBy, author, paginationToken, pageSize = HS_SEARCH_PAGE_SIZE }) {
+  const url = buildSearchUrl(keyword, searchText, ascending, sortBy, author, paginationToken, pageSize);
+  const items = await fetchJson(url, "resources");
+  if (!Array.isArray(items) || items.length === 0) {
+    return { resources: [], nextToken: null };
+  }
+  const resources = items.map(mapSearchResource);
+  const nextToken = resources.length === pageSize ? (items[items.length - 1].paginationToken ?? null) : null;
+  return { resources, nextToken };
 }
 
 // Helper function to fetch detailed metadata for a specific resource
@@ -256,195 +312,11 @@ async function fetchResourcesByKeyword(keyword, fullTextSearch=undefined) {
  * @param {boolean} ascending - Whether to sort results in ascending order (true) or descending order (false)
  * @param {string} sortBy - The field to sort by. One of 'title', 'author', 'created', 'modified'
  * @param {string} author - The author to filter by
- * @returns {Promise<Array>} Array of resource objects
+ * @param {string} paginationToken - Token from previous response for next page, or undefined for first page
+ * @returns {Promise<{resources: Array, nextToken: string|null}>}
  */
-async function fetchResourcesBySearch(keyword, searchText, ascending=false, sortBy=undefined, author=undefined, pageNumber=1) {
-  // Use hsapi/resource API (same as fetchResourcesByKeyword)
-  let url = `https://www.hydroshare.org/hsapi/resource/?subject=${encodeURIComponent(keyword)}&page=${pageNumber}&count=40`;
-
-  // Add search text if provided
-  if (searchText && searchText.trim()) {
-    url += `&full_text_search=${encodeURIComponent(searchText)}`;
-  }
-
-  console.log(`[fetchResourcesBySearch] URL: ${url}`);
-  console.log(`[fetchResourcesBySearch] KEYWORD: ${keyword}, PAGE: ${pageNumber}, SEARCH: "${searchText}"`);
-
-  // Fetch data from the API
-  const response = await fetch(url);
-  if (!response.ok) {
-    console.error(`[fetchResourcesBySearch] HTTP Error: ${response.status} ${response.statusText} for URL: ${url}`);
-    throw new Error(`Error fetching resources (status: ${response.status})`);
-  }
-  const data = await response.json();
-
-  console.log(`[fetchResourcesBySearch] Response received: count=${data.count}, results=${data.results?.length || 0}, for keyword="${keyword}"`);
-
-  // The API returns results directly as an array in data.results
-  const resources = data.results || [];
-
-  let resourcesCorrected = [];
-
-  for (let i = 0; i < resources.length; i++) {
-    let resource = resources[i];
-    let resourceCorrected = {
-      resource_id: resource.resource_id,
-      resource_title: resource.resource_title,
-      authors: resource.authors,
-      resource_type: resource.resource_type,
-      resource_url: resource.resource_url,
-      abstract: resource.abstract,
-      date_created: resource.date_created,
-      date_last_updated: resource.date_last_updated,
-    };
-
-    resourcesCorrected.push(resourceCorrected);
-  }
-
-  console.log(`[fetchResourcesBySearch] Returned ${resourcesCorrected.length} corrected resources for keyword="${keyword}"`);
-
-  // Return the corrected resources
-  return resourcesCorrected;
-}
-
-/**
- * Fetch resources from HydroShare based on search criteria and include pagination data in the returned object.
- * @param {string} keyword  - The keyword (subject) to use for the api request
- * @param {string} searchText - The text to look for in all the resource fields
- * @param {boolean} ascending - Whether to sort results in ascending order (true) or descending order (false)
- * @param {string} sortBy - The field to sort by. One of 'title', 'author', 'created', 'modified'
- * @param {string} author - The author to filter by
- * @param {number} pageNumber - The page number to fetch (1-based indexing)
- * @returns {Promise<Object>} Object containing resources array and pagination metadata
- */
-async function fetchResourcesWithPaginationData(keyword, searchText, ascending=false, sortBy=undefined, author=undefined, pageNumber=1) {
-  // API Url with query parameters
-  let url = `https://www.hydroshare.org/discoverapi/?q=${searchText ? encodeURIComponent(searchText) : ''}&subjects=${encodeURIComponent(keyword)}`;
-
-  // Add sort order parameter
-  if (ascending) {
-    url += `&asc=1`;
-  } else {
-    url += `&asc=-1`;
-  }
-
-  // Add sort parameter if provided
-  if (sortBy !== undefined) {
-    url += `&sort=${encodeURIComponent(sortBy)}`;
-  }
-
-  // Add page number parameter (1-based indexing)
-  url += `&pnum=${pageNumber}`;
-
-  console.log(`[fetchResourcesWithPaginationData] Fetching page ${pageNumber} with URL: ${url}`, {searchText: searchText || '(empty)'});
-
-  // Fetch data from the API
-  const response = await fetch(url);
-  if (!response.ok) {
-    console.error(`[fetchResourcesWithPaginationData] HTTP Error: ${response.status} ${response.statusText} for URL: ${url}`);
-    throw new Error(`Error fetching resources (status: ${response.status})`);
-  }
-  const data = await response.json();
-
-  // Put resources into a corrected format
-  let resources;
-
-  if (pageNumber > data.pagecount) {
-    resources = [];
-  } else {
-    if (typeof data.resources === "string") {
-        try {
-          resources = JSON.parse(data.resources);
-        } catch (e) {
-          console.error("Failed to parse data.resources as JSON string:", e);
-        resources = [];
-      }
-    } else if (Array.isArray(data.resources)) {
-      resources = data.resources;
-    } else {
-      console.warn("Unexpected format for data.resources:", data.resources);
-      resources = [];
-    }
-  }
-
-  let resourcesCorrected = [];
-
-  for (let i = 0; i < resources.length; i++) {
-    let resource = resources[i];
-    let resourceCorrected = {
-      resource_id: resource.short_id,
-      resource_title: resource.title,
-      authors: resource.authors,
-      resource_type: resource.type,
-      resource_url: 'https://www.hydroshare.org' + resource.link,
-      abstract: resource.abstract,
-      date_created: resource.created,
-      date_last_updated: resource.modified,
-    };
-
-    resourcesCorrected.push(resourceCorrected);
-  }
-
-  console.log(`[fetchResourcesWithPaginationData] Fetched ${resourcesCorrected.length} of ${data.rescount} total resources`);
-
-  // Return the corrected resources with pagination data
-  return {
-    resources: resourcesCorrected,
-    resourcesLength: resourcesCorrected.length,
-    resourceCountTotal: data.rescount,
-    pageCount: data.pagecount,
-    pageSize: data.perpage,
-    pageNumber: pageNumber,
-    pageLast: data.pagecount,
-    hasMorePages: pageNumber < data.pagecount,
-  };
-}
-
-/**
- * Fetch the pagination data for a given keyword and search criteria.
- * Uses the discoverapi endpoint to get resource count, page count, and resources per page.
- * @param {String} keyword The keyword/subject of the desired resources
- * @param {String} searchText The text to search for within the resources
- * @param {Boolean} ascending Whether to sort the results in ascending order
- * @param {String} sortBy The field to sort by. One of 'title', 'author', 'created', 'modified'
- * @param {String} author The author to filter the results by
- * @returns {Promise<Object>} An object containing pagination data
- */
-async function fetchKeywordPageData(keyword, searchText, ascending=false, sortBy=undefined, author=undefined) {
-  // API Url with query parameters
-  let url = `https://www.hydroshare.org/discoverapi/?q=${encodeURIComponent(searchText)}&subject=${encodeURIComponent(keyword)}`;
-
-  // Add sort order parameter
-  if (ascending) {
-    url += `&asc=1`;
-  } else {
-    url += `&asc=-1`;
-  }
-
-  // Add sort parameter if provided
-  if (sortBy !== undefined) {
-    url += `&sort=${encodeURIComponent(sortBy)}`;
-  }
-
-  // Add page number parameter (1-based indexing)
-  url += `&pnum=${1}`;
-
-  console.log(`[fetchKeywordPageData] Fetching page data with URL: ${url}`, {searchText: searchText || '(empty)'});
-
-  const response = await fetch(url);
-  if (!response.ok) {
-    console.error(`[fetchKeywordPageData] HTTP Error: ${response.status} ${response.statusText} for URL: ${url}`);
-    throw new Error(`Error fetching resources (status: ${response.status})`);
-  }
-  const data = await response.json();
-
-  console.log(`[fetchKeywordPageData] Total resources for keyword '${keyword}': ${data.rescount}, pages: ${data.pagecount}`);
-
-  return {
-    resourceCount: data.rescount,
-    pageCount: data.pagecount,
-    resourcesPerPage: data.perpage
-  };
+async function fetchResourcesBySearch(keyword, searchText, ascending=false, sortBy=undefined, author=undefined, paginationToken=undefined) {
+  return fetchSearchResourcesCore({ keyword, searchText, ascending, sortBy, author, paginationToken });
 }
 
 async function fetchResourceCustomMetadata(resourceId) {
@@ -481,7 +353,10 @@ export {
   fetchResource, 
   fetchResourcesByGroup, 
   fetchResourcesByKeyword, 
-  fetchResourcesBySearch, fetchResourcesWithPaginationData, fetchKeywordPageData, getCommunityResources, 
+  fetchResourcesBySearch,
+  fetchSearchResourcesCore,
+  HS_SEARCH_PAGE_SIZE,
+  getCommunityResources, 
   fetchResourceCustomMetadata, 
   joinExtraResources, 
   fetchRawCuratedResources,

--- a/src/components/Datasets/index.js
+++ b/src/components/Datasets/index.js
@@ -95,11 +95,10 @@ export default function Datasets({ community_id = 4 }) {
   const [activeTab, setActiveTab] = useState("all");
 
   // Pagination State
-  const [currentPage, setCurrentPage] = useState(1);
+  const [groupPage, setGroupPage] = useState(1);
+  const [searchToken, setSearchToken] = useState(undefined);
   const [hasMore, setHasMore] = useState(true);
   const fetching = useRef(false);
-  const lastFetchedPage = useRef(0); // Track the highest page number fetched
-  const fetchedPages = useRef(new Set()); // Track fetched pages
 
   // Search State
   const [searchInput,    setSearchInput]    = useState('');
@@ -109,27 +108,17 @@ export default function Datasets({ community_id = 4 }) {
 
   // Fetch all resources by group, then filter them based on curated IDs
   const fetchAll = useCallback(
-    async (page) => {
+    async (paginationToken, groupPage) => {
       // Prevent concurrent fetches
       if (fetching.current) return;
-      
-      // Prevent refetching same or lower page numbers
-      if (page <= lastFetchedPage.current) {
-        return;
-      }
-
-      if (fetchedPages.current.has(page)) {
-        return;
-      }
-      
       fetching.current = true;
 
       // Add placeholders for loading state (only for pagination, not first page)
-      if (page > 1) {
+      if (paginationToken !== undefined || groupPage > 1) {
         setResources(prev => [
           ...prev,
           ...Array.from({ length: PAGE_SIZE }, (_, i) => ({
-            resource_id: `placeholder-page${page}-${i}`,
+            resource_id: `placeholder-${Date.now()}-${i}`,
             title: "",
             authors: "",
             resource_type: "",
@@ -151,14 +140,16 @@ export default function Datasets({ community_id = 4 }) {
       try {
         const [curatedIds, communityResourcesResponse] = await Promise.all([
           fetchCuratedIds(),                // get array of curated resource IDs
-          getCommunityResources("ciroh_portal_data,ciroh_hub_data", "4", fullTextSearch, ascending, sortBy, undefined, page, PAGE_SIZE) // get all resources for the group
+          getCommunityResources("ciroh_portal_data,ciroh_hub_data", "4", fullTextSearch, ascending, sortBy, undefined, paginationToken, PAGE_SIZE, groupPage)
         ]);
 
         const resourceList = communityResourcesResponse.resources;
-        fetchedPages.current.add(page);
 
         // Update pagination state
-        setHasMore(communityResourcesResponse.groupResourcesPageData.hasMorePages || communityResourcesResponse.extraResourcesPageData.hasMorePages);
+        const searchNextToken = communityResourcesResponse.extraResourcesPageData?.nextToken ?? null;
+        const groupHasMore = communityResourcesResponse.groupResourcesPageData?.hasMorePages ?? false;
+        setSearchToken(searchNextToken);
+        setHasMore(groupHasMore || !!searchNextToken);
 
         // Map the full resource list to your internal format
         let mappedList = resourceList.map((res) => ({
@@ -180,7 +171,7 @@ export default function Datasets({ community_id = 4 }) {
         // Sort locally to account for curated resources
         mappedList = sortResources(mappedList, sortBy, sortDirection);
 
-        if (page === 1) {
+        if (paginationToken === undefined && groupPage === 1) {
           setResources(mappedList);
         } else {
           // Replace placeholders from this page with actual data
@@ -198,7 +189,7 @@ export default function Datasets({ community_id = 4 }) {
         curatedSubset = sortResources(curatedSubset, sortBy, sortDirection);
         
         // Accumulate curated resources across pages (like main resources)
-        if (page === 1) {
+        if (paginationToken === undefined && groupPage === 1) {
           setCuratedResources(curatedSubset);
         } else {
           // Replace placeholders from this page with actual data
@@ -208,11 +199,6 @@ export default function Datasets({ community_id = 4 }) {
           ]);
         }
         setLoading(false);
-
-        // Update the last fetched page tracker (only if this page is higher)
-        if (page > lastFetchedPage.current) {
-          lastFetchedPage.current = page;
-        }
 
         // Allow pagination to continue - core data is loaded
         fetching.current = false;
@@ -253,20 +239,15 @@ export default function Datasets({ community_id = 4 }) {
   useEffect(() => {
     setResources(initialPlaceholders);
     setCuratedResources(initialPlaceholders);
-    setCurrentPage(1);
     setHasMore(true);
+    setSearchToken(undefined);
+    setGroupPage(1);
     
     // Reset the fetching flag to allow new requests
     fetching.current = false;
     
-    // Reset the last fetched page tracker
-    lastFetchedPage.current = 0;
-    
-    // Reset the fetched pages set
-    fetchedPages.current.clear();
-    
     // Fetch first page with new filters
-    fetchAll(1);
+    fetchAll(undefined, 1);
   }, [filterSearch, sortDirection, sortType, fetchAll]);
 
   /* infinite scroll */
@@ -275,14 +256,14 @@ export default function Datasets({ community_id = 4 }) {
       if (fetching.current || !hasMore) return;
       const { scrollTop, clientHeight, scrollHeight } = document.documentElement;
       if (scrollTop + clientHeight >= scrollHeight - SCROLL_THRESHOLD) {
-        const next = currentPage + 1;
-        setCurrentPage(next);
-        fetchAll(next);
+        const nextGroupPage = groupPage + 1;
+        setGroupPage(nextGroupPage);
+        fetchAll(searchToken, nextGroupPage);
       }
     };
     window.addEventListener('scroll', onScroll);
     return () => window.removeEventListener('scroll', onScroll);
-  }, [currentPage, hasMore, fetchAll]);
+  }, [hasMore, searchToken, groupPage, fetchAll]);
 
   /* search helpers */
   const commitSearch = q => {

--- a/src/components/HomepageFeatures/ResearchFeature/index.js
+++ b/src/components/HomepageFeatures/ResearchFeature/index.js
@@ -45,43 +45,26 @@ export default function ResearchFeature() {
     // Count resources for a single keyword, paging until exhausted
     async function hsCountByKeyword(keyword) {
         let total = 0;
-        let page = 1;
-        let totalPagesChecked = 0;
+        let paginationToken = undefined;
         try {
             console.log(`[hsCountByKeyword] Starting count for: ${keyword}`);
             while (true) {
-                const results = await fetchResourcesBySearch(
-                keyword,
-                "",         // searchText
-                false,      // ascending
-                "modified", // sortBy
-                undefined,  // author
-                page
+                const { resources: items, nextToken } = await fetchResourcesBySearch(
+                    keyword,
+                    "",         // searchText
+                    false,      // ascending
+                    "modified", // sortBy
+                    undefined,  // author
+                    paginationToken
                 );
 
-                // Support wrappers that return array or { resources: [...] }
-                const items = Array.isArray(results) ? results : (results?.resources || []);
-
-                console.log(`[hsCountByKeyword] Page ${page}: ${items.length} items returned for ${keyword}`);
-                totalPagesChecked++;
-
-                if (!items || items.length === 0) {
-                    console.log(`[hsCountByKeyword] No more items on page ${page}, stopping`);
-                    break;
-                }
-
+                if (!items || items.length === 0) break;
                 total += items.length;
-
-                // stop when a page is short (no more pages)
-                if (items.length < 40) {
-                    console.log(`[hsCountByKeyword] Short page (${items.length} < 40), stopping`);
-                    break;
-                }
-                page++;
+                if (!nextToken) break;
+                paginationToken = nextToken;
             }
-            console.log(`[hsCountByKeyword] ${keyword}: Total ${total} resources across ${totalPagesChecked} pages`);
         } catch (err) {
-            console.error(`[hsCountByKeyword] ${keyword} error after ${totalPagesChecked} pages:`, err);
+            console.error(`[hsCountByKeyword] ${keyword} error:`, err);
             throw err;
         }
         return total;
@@ -89,8 +72,8 @@ export default function ResearchFeature() {
 
     // Count community resources (matches datasets page behavior)
     async function hsCountCommunityResources(keyword, communityId = "4") {
-        let page = 1;
-        let totalPagesChecked = 0;
+        let paginationToken = undefined;
+        let groupPage = 1;
         const resourceIds = new Set();
         try {
             console.log(`[hsCountCommunityResources] Starting count for: ${keyword}`);
@@ -102,35 +85,27 @@ export default function ResearchFeature() {
                   false,      // ascending
                   "modified", // sortBy
                   undefined,  // author
-                  page,
-                  40          // pageSize
+                  paginationToken,
+                  40,         // pageSize
+                  groupPage
                 );
 
                 const items = response?.resources || [];
-                totalPagesChecked++;
-
                 items.forEach((item) => {
-                    if (item?.resource_id) {
-                        resourceIds.add(item.resource_id);
-                    }
+                    if (item?.resource_id) resourceIds.add(item.resource_id);
                 });
 
-                const hasMorePages = Boolean(
-                    response?.groupResourcesPageData?.hasMorePages ||
-                    response?.extraResourcesPageData?.hasMorePages
-                );
+                const groupHasMore = Boolean(response?.groupResourcesPageData?.hasMorePages);
+                const searchNextToken = response?.extraResourcesPageData?.nextToken ?? null;
 
-                console.log(`[hsCountCommunityResources] Page ${page}: ${items.length} items returned for ${keyword}`);
+                if (!groupHasMore && !searchNextToken) break;
+                if (items.length === 0) break;
 
-                if (!hasMorePages || items.length === 0) {
-                    console.log(`[hsCountCommunityResources] No more items on page ${page}, stopping`);
-                    break;
-                }
-                page++;
+                if (groupHasMore) groupPage++;
+                paginationToken = searchNextToken;
             }
-            console.log(`[hsCountCommunityResources] ${keyword}: Total ${resourceIds.size} resources across ${totalPagesChecked} pages`);
         } catch (err) {
-            console.error(`[hsCountCommunityResources] ${keyword} error after ${totalPagesChecked} pages:`, err);
+            console.error(`[hsCountCommunityResources] ${keyword} error:`, err);
             throw err;
         }
         return resourceIds.size;

--- a/src/components/HydroShareImporter/index.js
+++ b/src/components/HydroShareImporter/index.js
@@ -1,3 +1,4 @@
+import { fetchSearchResourcesCore, HS_SEARCH_PAGE_SIZE } from "@site/src/api/hydroshareAPI";
 const { XMLParser } = require("fast-xml-parser");
 
 /**
@@ -10,30 +11,6 @@ const { XMLParser } = require("fast-xml-parser");
  * Adjust or add query parameters (e.g., page, count) as needed.
  */
 
-/**
- * Convert author name from "First Middle Last" to "Last, First Middle"
- * @param {string} author - The author name in "First Middle Last" format
- * @returns {string} The author name in "Last, First Middle" format
- */
-function convertAuthorToLastFirst(author) {
-  if (!author || typeof author !== 'string') {
-    return author;
-  }
-  
-  const nameParts = author.split(' ');
-
-  if (nameParts.length === 1) {
-    // Single-word name, leave as-is
-    author = nameParts[0];
-  } else {
-    const lastName = nameParts.pop();
-    const firstName = nameParts.join(' ');
-    author = `${lastName}, ${firstName}`;
-  }
-
-  return author;
-}
-
 async function fetchJson(url, errorContext = "resources") {
   const response = await fetch(url);
   if (!response.ok) {
@@ -41,80 +18,6 @@ async function fetchJson(url, errorContext = "resources") {
   }
   return response.json();
 }
-
-function buildDiscoverApiUrl(
-  keyword,
-  searchText,
-  ascending = false,
-  sortBy = undefined,
-  author = undefined,
-  pageNumber = 1,
-) {
-  const filterAuthor = author !== undefined ? convertAuthorToLastFirst(author) : undefined;
-  const filter = {
-    author: [filterAuthor].filter(a => a !== undefined),
-    subject: keyword.split(","),
-  };
-  const params = new URLSearchParams({
-    q: searchText ? searchText : "",
-    subject: keyword,
-    asc: ascending ? "1" : "-1",
-    pnum: pageNumber.toString(),
-    filter: JSON.stringify(filter),
-  });
-  if (sortBy !== undefined) {
-    params.set("sort", sortBy);
-  }
-  return `https://www.hydroshare.org/discoverapi/?${params.toString()}`;
-}
-
-function mapDiscoverResource(resource) {
-  return {
-    resource_id: resource.short_id,
-    resource_title: resource.title,
-    authors: resource.authors,
-    resource_type: resource.type,
-    resource_url: `https://www.hydroshare.org${resource.link}`,
-    abstract: resource.abstract,
-    date_created: resource.created,
-    date_last_updated: resource.modified,
-  };
-}
-
-function parseDiscoverResources(data, { pageNumber } = {}) {
-  if (pageNumber !== undefined && pageNumber > data.pagecount) {
-    return [];
-  }
-
-  if (typeof data.resources === "string") {
-    try {
-      return JSON.parse(data.resources).map(mapDiscoverResource);
-    } catch (error) {
-      console.error("Failed to parse data.resources as JSON string:", error);
-      return [];
-    }
-  }
-
-  if (Array.isArray(data.resources)) {
-    return data.resources.map(mapDiscoverResource);
-  }
-
-  console.warn("Unexpected format for data.resources:", data.resources);
-  return [];
-}
-
-// Helper function to fetch detailed metadata for a specific resource
-// async function fetchResourceMetadata(resourceId="302dcbef13614ac486fb260eaa1ca87c") {
-//   const url = `https://www.hydroshare.org/hsapi/resource/${resourceId}/scimeta/elements/`;
-//   const response = await fetch(url);
-//   if (!response.ok) {
-//     throw new Error(
-//       `Error fetching metadata for resource ${resourceId} (status: ${response.status})`
-//     );
-//   }
-//   const metadata = await response.json();
-//   return metadata;
-// }
 
 async function fetchResource(id) {
   const url = `https://www.hydroshare.org/hsapi/resource/${encodeURIComponent(id)}/sysmeta`;
@@ -262,13 +165,17 @@ function joinExtraResources(groupResources, extraResources) {
 
 }
 
-async function getCommunityResources(keyword="ciroh_portal_data,ciroh_hub_data", communityId="4", fullTextSearch=undefined, ascending=false, sortBy=undefined, author=undefined, pageNumber=undefined, pageSize=undefined) {
+async function getCommunityResources(keyword="ciroh_portal_data,ciroh_hub_data", communityId="4", fullTextSearch=undefined, ascending=false, sortBy=undefined, author=undefined, paginationToken=undefined, pageSize=HS_SEARCH_PAGE_SIZE, groupPage=1) {
   try {
-    // Fetch resources
     const groupIds = await getGroupIds(communityId);
+    // paginationToken === null means search is exhausted; skip the search call.
+    // paginationToken === undefined means first page; fetch normally.
+    const searchExhausted = paginationToken === null;
     const [groupResourcesResponse, extraResourcesResponse] = await Promise.all([
-      joinGroupResources(groupIds, fullTextSearch, pageNumber, pageSize),
-      fetchResourcesWithPaginationData(keyword, fullTextSearch, ascending, sortBy, author, pageNumber)
+      joinGroupResources(groupIds, fullTextSearch, groupPage, pageSize),
+      searchExhausted
+        ? Promise.resolve({ resources: [], resourcesLength: 0, nextToken: null })
+        : fetchResourcesWithPaginationData(keyword, fullTextSearch, ascending, sortBy, author, paginationToken, pageSize)
     ]);
 
     // Extract resources
@@ -282,9 +189,7 @@ async function getCommunityResources(keyword="ciroh_portal_data,ciroh_hub_data",
       groupResourcesPageData: groupResourcesResponse,
       extraResourcesPageData: extraResourcesResponse,
       resources: joinedResources
-    }
-
-    // return await joinGroupResources(groupIds);
+    };
   } catch (error) {
     console.error('Community resource fetch failed:', error);
     return {};
@@ -307,24 +212,6 @@ async function fetchResourcesByKeyword(keyword, { page = 1, count = 15, fullText
   return data.results;
 }
 
-async function fetchDiscoverResourcesCore({
-  keyword,
-  searchText,
-  ascending = false,
-  sortBy = undefined,
-  author = undefined,
-  pageNumber = 1,
-  clampToPageCount = false,
-}) {
-  const url = buildDiscoverApiUrl(keyword, searchText, ascending, sortBy, author, pageNumber);
-  const data = await fetchJson(url, "resources");
-  const resources = parseDiscoverResources(
-    data,
-    clampToPageCount ? { pageNumber } : undefined,
-  );
-  return { data, resources };
-}
-
 /**
  * Fetch resources from HydroShare based on search criteria.
  * @param {string} keyword  - The keyword (subject) to use for the api request
@@ -332,18 +219,12 @@ async function fetchDiscoverResourcesCore({
  * @param {boolean} ascending - Whether to sort results in ascending order (true) or descending order (false)
  * @param {string} sortBy - The field to sort by. One of 'title', 'author', 'created', 'modified'
  * @param {string} author - The author to filter by
- * @returns {Promise<Array>} Array of resource objects
+ * @param {string} paginationToken - Token from previous response for next page, or undefined for first page
+ * @param {number} pageSize - Number of results per page
+ * @returns {Promise<{resources: Array, nextToken: string|null}>}
  */
-async function fetchResourcesBySearch(keyword, searchText, ascending=false, sortBy=undefined, author=undefined, pageNumber=1) {
-  const { resources } = await fetchDiscoverResourcesCore({
-    keyword,
-    searchText,
-    ascending,
-    sortBy,
-    author,
-    pageNumber,
-  });
-  return resources;
+async function fetchResourcesBySearch(keyword, searchText, ascending=false, sortBy=undefined, author=undefined, paginationToken=undefined, pageSize=HS_SEARCH_PAGE_SIZE) {
+  return fetchSearchResourcesCore({ keyword, searchText, ascending, sortBy, author, paginationToken, pageSize });
 }
 
 /**
@@ -353,51 +234,16 @@ async function fetchResourcesBySearch(keyword, searchText, ascending=false, sort
  * @param {boolean} ascending - Whether to sort results in ascending order (true) or descending order (false)
  * @param {string} sortBy - The field to sort by. One of 'title', 'author', 'created', 'modified'
  * @param {string} author - The author to filter by
- * @param {number} pageNumber - The page number to fetch (1-based indexing)
- * @returns {Promise<Object>} Object containing resources array and pagination metadata
+ * @param {string} paginationToken - Token from previous response for next page, or undefined for first page
+ * @param {number} pageSize - Number of results per page
+ * @returns {Promise<{resources: Array, resourcesLength: number, nextToken: string|null}>}
  */
-async function fetchResourcesWithPaginationData(keyword, searchText, ascending=false, sortBy=undefined, author=undefined, pageNumber=1) {
-  const { data, resources } = await fetchDiscoverResourcesCore({
-    keyword,
-    searchText,
-    ascending,
-    sortBy,
-    author,
-    pageNumber,
-    clampToPageCount: true,
-  });
-
-  // Return the corrected resources with pagination data
+async function fetchResourcesWithPaginationData(keyword, searchText, ascending=false, sortBy=undefined, author=undefined, paginationToken=undefined, pageSize=HS_SEARCH_PAGE_SIZE) {
+  const { resources, nextToken } = await fetchSearchResourcesCore({ keyword, searchText, ascending, sortBy, author, paginationToken, pageSize });
   return {
     resources,
     resourcesLength: resources.length,
-    resourceCountTotal: data.rescount,
-    pageCount: data.pagecount,
-    pageSize: data.perpage,
-    pageNumber: pageNumber,
-    pageLast: data.pagecount,
-    hasMorePages: pageNumber < data.pagecount,
-  };
-}
-
-/**
- * Fetch the pagination data for a given keyword and search criteria.
- * Uses the discoverapi endpoint to get resource count, page count, and resources per page.
- * @param {String} keyword The keyword/subject of the desired resources
- * @param {String} searchText The text to search for within the resources
- * @param {Boolean} ascending Whether to sort the results in ascending order
- * @param {String} sortBy The field to sort by. One of 'title', 'author', 'created', 'modified'
- * @param {String} author The author to filter the results by
- * @returns {Promise<Object>} An object containing pagination data
- */
-async function fetchKeywordPageData(keyword, searchText, ascending=false, sortBy=undefined, author=undefined) {
-  const url = buildDiscoverApiUrl(keyword, searchText, ascending, sortBy, author, 1);
-  const data = await fetchJson(url, "resources");
-
-  return {
-    resourceCount: data.rescount,
-    pageCount: data.pagecount,
-    resourcesPerPage: data.perpage
+    nextToken,
   };
 }
 
@@ -594,12 +440,13 @@ export {
   fetchResourcesByGroup, 
   fetchResourcesByKeyword, 
   fetchResourcesByKeywordsIntersection,
-  fetchResourcesBySearch, fetchResourcesWithPaginationData, fetchKeywordPageData, getCommunityResources, 
+  fetchResourcesBySearch,
+  fetchResourcesWithPaginationData,
+  getCommunityResources, 
   fetchResourceCustomMetadata, 
   fetchResourceMetadata,
   joinExtraResources, 
   fetchRawCuratedResources,
-  convertAuthorToLastFirst,
   fetchResourcesFromCollection,
   fetchResourceImageUrls
 };

--- a/src/components/HydroShareResourcesSelector/index.js
+++ b/src/components/HydroShareResourcesSelector/index.js
@@ -78,7 +78,7 @@ export default function HydroShareResourcesSelector({
           setResources(prev => [
             ...prev,
             ...Array.from({ length: pageSize }, (_, i) => ({
-              resource_id: `placeholder-load-${i}`,
+              resource_id: `placeholder-load-${Date.now()}-${i}`,
               title: "",
               authors: "",
               resource_type: "",

--- a/src/components/HydroShareResourcesSelector/index.js
+++ b/src/components/HydroShareResourcesSelector/index.js
@@ -15,7 +15,7 @@ import {
   HiOutlineSearch,
 } from 'react-icons/hi';
 
-const PAGE_SIZE        = 40;
+const DEFAULT_PAGE_SIZE = 40;
 const SCROLL_THRESHOLD = 800;
 let   debounceTimer    = null;
 const DEBOUNCE_MS      = 1_000;
@@ -25,6 +25,7 @@ export default function HydroShareResourcesSelector({
   defaultImage,
   variant = 'legacy',
   onResultsChange,
+  pageSize = DEFAULT_PAGE_SIZE,
 }) {
   const { colorMode } = useColorMode(); // Get the current theme
   const PLACEHOLDER_ITEMS = 10;
@@ -52,6 +53,8 @@ export default function HydroShareResourcesSelector({
   const [view, setView] = useState("row");
   const [currentPage, setCurrentPage] = useState(1);
   const [hasMore, setHasMore] = useState(true);
+  const [nextToken, setNextToken] = useState(undefined);
+  const [groupPage, setGroupPage] = useState(1);
   const fetching = useRef(false);
 
   // Search State
@@ -63,7 +66,7 @@ export default function HydroShareResourcesSelector({
 
 
   const fetchResources = useCallback(
-    async (page) => {
+    async (paginationToken, currentGroupPage) => {
       if (fetching.current) return;
       fetching.current = true;
 
@@ -71,11 +74,11 @@ export default function HydroShareResourcesSelector({
         let resourceList = undefined;
         
         // Add placeholders for loading state (only for pagination, not first page)
-        if (page > 1) {
+        if (paginationToken !== undefined || currentGroupPage > 1) {
           setResources(prev => [
             ...prev,
-            ...Array.from({ length: PAGE_SIZE }, (_, i) => ({
-              resource_id: `placeholder-page${page}-${i}`,
+            ...Array.from({ length: pageSize }, (_, i) => ({
+              resource_id: `placeholder-load-${i}`,
               title: "",
               authors: "",
               resource_type: "",
@@ -96,10 +99,14 @@ export default function HydroShareResourcesSelector({
         let communityResponse = null;
         if (keyword.includes('data')) {
           const firstKeyword = keyword.split(',')[0].trim();
-          communityResponse = await getCommunityResources(firstKeyword, "4", filterSearch, ascending, sortType, undefined, page, PAGE_SIZE);
+          communityResponse = await getCommunityResources(firstKeyword, "4", filterSearch, ascending, sortType, undefined, paginationToken, pageSize, currentGroupPage);
           resourceList = communityResponse.resources || [];
         } else {
-          resourceList = await fetchResourcesBySearch(keyword, filterSearch, ascending, sortType, undefined, page);
+          const result = await fetchResourcesBySearch(keyword, filterSearch, ascending, sortType, undefined, paginationToken, pageSize);
+          resourceList = result.resources;
+          const newToken = result.nextToken;
+          setNextToken(newToken);
+          setHasMore(!!newToken);
         }
 
         const mappedList = resourceList.map((res) => ({
@@ -120,7 +127,7 @@ export default function HydroShareResourcesSelector({
         }));
 
         // Handle first page vs pagination
-        if (page === 1) {
+        if (paginationToken === undefined && currentGroupPage === 1) {
           setResources(mappedList); // Replace for first page
         } else {
           setResources(prev => [
@@ -132,10 +139,10 @@ export default function HydroShareResourcesSelector({
         // Update hasMore based on API response
         if (communityResponse) {
           // For datasets using getCommunityResources
-          setHasMore(communityResponse.groupResourcesPageData?.hasMorePages || communityResponse.extraResourcesPageData?.hasMorePages || false);
-        } else {
-          // For other resources using fetchResourcesBySearch
-          setHasMore(mappedList.length === PAGE_SIZE);
+          const searchNextToken = communityResponse.extraResourcesPageData?.nextToken ?? null;
+          const groupHasMore = communityResponse.groupResourcesPageData?.hasMorePages ?? false;
+          setNextToken(searchNextToken);
+          setHasMore(groupHasMore || !!searchNextToken);
         }
         setLoading(false);
 
@@ -170,7 +177,7 @@ export default function HydroShareResourcesSelector({
         fetching.current = false;
       }
     },
-    [keyword, filterSearch, sortDirection, sortType, hs_icon]
+    [keyword, filterSearch, sortDirection, sortType, hs_icon, pageSize]
   );
 
 
@@ -180,11 +187,13 @@ export default function HydroShareResourcesSelector({
     setResources(initialPlaceholders);
     setCurrentPage(1);
     setHasMore(true);
+    setNextToken(undefined);
+    setGroupPage(1);
     
     // Reset the fetching flag to allow new requests (fixes race condition)
     fetching.current = false;
     
-    fetchResources(1);
+    fetchResources(undefined, 1);
   }, [keyword, filterSearch, sortDirection, sortType, fetchResources]);
 
   const nonPlaceholderResources = useMemo(
@@ -217,10 +226,6 @@ export default function HydroShareResourcesSelector({
     onResultsChange,
   ]);
 
-  if (error) {
-    return <p style={{ color: "red" }}>Error: {error}</p>;
-  }
-
   /* infinite scroll */
   useEffect(() => {
     const onScroll = () => {
@@ -228,13 +233,19 @@ export default function HydroShareResourcesSelector({
       const { scrollTop, clientHeight, scrollHeight } = document.documentElement;
       if (scrollTop + clientHeight >= scrollHeight - SCROLL_THRESHOLD) {
         const next = currentPage + 1;
+        const nextGroup = groupPage + 1;
         setCurrentPage(next);
-        fetchResources(next);
+        setGroupPage(nextGroup);
+        fetchResources(nextToken, nextGroup);
       }
     };
     window.addEventListener('scroll', onScroll);
     return () => window.removeEventListener('scroll', onScroll);
-  }, [currentPage, hasMore, fetchResources]);
+  }, [currentPage, hasMore, nextToken, groupPage, fetchResources]);
+
+  if (error) {
+    return <p style={{ color: "red" }}>Error: {error}</p>;
+  }
 
   /* search helpers */
   const commitSearch = (q) => {

--- a/src/components/Presentations/index.js
+++ b/src/components/Presentations/index.js
@@ -126,7 +126,6 @@ export default function Presentations({ community_id = 4 }) {
   const [activeTab, setActiveTab] = useState("presentations");
 
   // Pagination State
-  const [currentPage, setCurrentPage] = useState(1);
   const [hasMore, setHasMore] = useState(true);
   const [presPageNextToken, setPresPageNextToken] = useState(undefined);
   const fetching = useRef(false);
@@ -160,15 +159,11 @@ export default function Presentations({ community_id = 4 }) {
 
 
   const fetchAll = useCallback(
-    async (page) => {
+    async () => {
       if (fetching.current) return;
       fetching.current = true;
 
       try {
-        // Add placeholders for loading state (only for pagination, not first page)
-        if (page > 1) {
-          addPlaceholderResources(page);
-        }
 
         // Search parameters
         const ascending = sortDirection === 'asc';
@@ -234,16 +229,7 @@ export default function Presentations({ community_id = 4 }) {
         const mappedResources = await mapWithCustomMetadata(rawResources, hs_icon);
         const mappedCollections = await mapWithCustomMetadata(rawCollections, hs_icon);
         
-        // Handle first page vs pagination
-        if (page === 1) {
-          setResources(mappedResources);
-        } else {
-          setResources(prev => [
-            ...prev.filter(r => !r.resource_id.startsWith('placeholder-')),
-            ...mappedResources
-          ]);
-        }
-
+        setResources(mappedResources);
         setCollections(mappedCollections);
         //setCuratedResources(mappedCurated);
 
@@ -257,7 +243,7 @@ export default function Presentations({ community_id = 4 }) {
         fetching.current = false;
       }
     },
-    [addPlaceholderResources, hs_icon, sortDirection, sortType, filterSearch, usingSearch]
+    [hs_icon, sortDirection, sortType, filterSearch, usingSearch]
   );
 
   const fetchPage = useCallback(
@@ -267,7 +253,7 @@ export default function Presentations({ community_id = 4 }) {
 
       try {
         // Add placeholders for loading state
-        addPlaceholderResources(currentPage + 1);
+        addPlaceholderResources(Date.now());
 
         // Search parameters
         const ascending = sortDirection === 'asc';
@@ -284,15 +270,11 @@ export default function Presentations({ community_id = 4 }) {
         // Map the full resource lists to your internal format (with custom metadata)
         const mappedResources = await mapWithCustomMetadata(rawKeywordResources, hs_icon);
         
-        // Handle first page vs pagination
-        if (page === 1) {
-          setResources(mappedResources);
-        } else {
-          setResources(prev => [
-            ...prev.filter(r => !r.resource_id.startsWith('placeholder-')),
-            ...mappedResources
-          ]);
-        }
+        // Append to existing resources (fetchPage is never called for the first page)
+        setResources(prev => [
+          ...prev.filter(r => !r.resource_id.startsWith('placeholder-')),
+          ...mappedResources
+        ]);
 
         //setCuratedResources(mappedCurated);
 
@@ -306,20 +288,19 @@ export default function Presentations({ community_id = 4 }) {
         fetching.current = false;
       }
     },
-    [addPlaceholderResources, hs_icon, sortDirection, sortType, filterSearch]
+    [addPlaceholderResources, hs_icon, sortDirection, sortType, filterSearch, presPageNextToken]
   );
 
   // Reset and load first page when filters change
   useEffect(() => {
     setResources(initialPlaceholders);
-    setCurrentPage(1);
     setHasMore(true);
     setPresPageNextToken(undefined);
     
     // Reset the fetching flag to allow new requests
     fetching.current = false;
     
-    fetchAll(1); // Use fetchAll for first page (includes curated resources)
+    fetchAll(); // Use fetchAll for first page (includes curated resources)
   }, [filterSearch, sortDirection, sortType, fetchAll]);
 
   /* infinite scroll */
@@ -329,14 +310,12 @@ export default function Presentations({ community_id = 4 }) {
       if (fetching.current || !hasMore) return;
       const { scrollTop, clientHeight, scrollHeight } = document.documentElement;
       if (scrollTop + clientHeight >= scrollHeight - SCROLL_THRESHOLD) {
-        const next = currentPage + 1;
-        setCurrentPage(next);
         fetchPage();
       }
     };
     window.addEventListener('scroll', onScroll);
     return () => window.removeEventListener('scroll', onScroll);
-  }, [currentPage, hasMore, fetchPage]);
+  }, [hasMore, fetchPage]);
 
   /* search helpers */
   const commitSearch = q => {

--- a/src/components/Presentations/index.js
+++ b/src/components/Presentations/index.js
@@ -7,7 +7,6 @@ import HydroShareResourcesRows from "@site/src/components/HydroShareResourcesRow
 import { 
   fetchResource,
   fetchResourcesBySearch,
-  fetchKeywordPageData, 
   getCuratedIds,
   fetchResourceCustomMetadata, 
   joinExtraResources 
@@ -128,7 +127,8 @@ export default function Presentations({ community_id = 4 }) {
 
   // Pagination State
   const [currentPage, setCurrentPage] = useState(1);
-  const [lastPage, setLastPage] = useState(1);
+  const [hasMore, setHasMore] = useState(true);
+  const [presPageNextToken, setPresPageNextToken] = useState(undefined);
   const fetching = useRef(false);
 
   // Search State
@@ -174,15 +174,18 @@ export default function Presentations({ community_id = 4 }) {
         const ascending = sortDirection === 'asc';
 
         // Retrieve resources
-        let [rawCuratedResources, invKeywordResources, invCollections, pageData] = await Promise.all([
+        let [rawCuratedResources, presResult, collResult] = await Promise.all([
           fetchRawCuratedResources(CURATED_PARENT_ID), // get array of curated resource IDs
-          fetchResourcesBySearch('ciroh_portal_presentation,ciroh_hub_presentation', filterSearch, ascending, sortType, undefined, page),
-          fetchResourcesBySearch('ciroh_portal_pres_collections', filterSearch, ascending, sortType, undefined, page),
-          fetchKeywordPageData('ciroh_portal_presentation,ciroh_hub_presentation', filterSearch, ascending, sortType, undefined)
+          fetchResourcesBySearch('ciroh_portal_presentation,ciroh_hub_presentation', filterSearch, ascending, sortType, undefined, undefined, PAGE_SIZE),
+          fetchResourcesBySearch('ciroh_portal_pres_collections', filterSearch, ascending, sortType, undefined, undefined, PAGE_SIZE),
         ]);
 
-        // Set last page
-        setLastPage(pageData.pageCount);
+        const invKeywordResources = presResult.resources;
+        const invCollections = collResult.resources;
+
+        // Capture the pagination token from the first page so fetchPage can continue from here
+        setPresPageNextToken(presResult.nextToken ?? null);
+        setHasMore(!!presResult.nextToken);
         
         // Apply search filtering to curated resources
         if (usingSearch()) {
@@ -258,27 +261,23 @@ export default function Presentations({ community_id = 4 }) {
   );
 
   const fetchPage = useCallback(
-    async (page) => {
+    async () => {
       if (fetching.current) return;
       fetching.current = true;
 
       try {
-        // Add placeholders for loading state (only for pagination, not first page)
-        if (page > 1) {
-          addPlaceholderResources(page);
-        }
+        // Add placeholders for loading state
+        addPlaceholderResources(currentPage + 1);
 
         // Search parameters
         const ascending = sortDirection === 'asc';
 
         // Retrieve resources
-        let [invKeywordResources, pageData] = await Promise.all([
-          fetchResourcesBySearch('ciroh_portal_presentation', filterSearch, ascending, sortType, undefined, page),
-          fetchKeywordPageData('ciroh_portal_presentation', filterSearch, ascending, sortType, undefined)
-        ]);
+        const { resources: invKeywordResources, nextToken } = await fetchResourcesBySearch('ciroh_portal_presentation', filterSearch, ascending, sortType, undefined, presPageNextToken, PAGE_SIZE);
 
-        // Set last page
-        setLastPage(pageData.pageCount);
+        // Update token and hasMore for subsequent pages
+        setPresPageNextToken(nextToken);
+        setHasMore(!!nextToken);
 
         const rawKeywordResources = invKeywordResources.reverse(); // Reverse chronological order
 
@@ -314,6 +313,8 @@ export default function Presentations({ community_id = 4 }) {
   useEffect(() => {
     setResources(initialPlaceholders);
     setCurrentPage(1);
+    setHasMore(true);
+    setPresPageNextToken(undefined);
     
     // Reset the fetching flag to allow new requests
     fetching.current = false;
@@ -325,17 +326,17 @@ export default function Presentations({ community_id = 4 }) {
   useEffect(() => {
     const onScroll = () => {
       // Check if we can fetch more pages
-      if (fetching.current || currentPage >= lastPage) return;
+      if (fetching.current || !hasMore) return;
       const { scrollTop, clientHeight, scrollHeight } = document.documentElement;
       if (scrollTop + clientHeight >= scrollHeight - SCROLL_THRESHOLD) {
         const next = currentPage + 1;
         setCurrentPage(next);
-        fetchPage(next);
+        fetchPage();
       }
     };
     window.addEventListener('scroll', onScroll);
     return () => window.removeEventListener('scroll', onScroll);
-  }, [currentPage, lastPage, fetchPage]);
+  }, [currentPage, hasMore, fetchPage]);
 
   /* search helpers */
   const commitSearch = q => {

--- a/src/components/ResourceBrowser/index.js
+++ b/src/components/ResourceBrowser/index.js
@@ -24,7 +24,7 @@ export default function ResourceBrowser({
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [hasMore, setHasMore] = useState(true);
-  const [currentPage, setCurrentPage] = useState(1);
+  const [nextToken, setNextToken] = useState(undefined);
 
   const [searchInput, setSearchInput] = useState('');
   const [activeSearch, setActiveSearch] = useState('');
@@ -56,7 +56,7 @@ export default function ResourceBrowser({
     resourceUrl: res.resource_url,
   }), []);
 
-  const fetchPage = useCallback(async (page, replace = false) => {
+  const fetchPage = useCallback(async (paginationToken = undefined, replace = false) => {
     if (fetchingRef.current) return;
     fetchingRef.current = true;
 
@@ -71,26 +71,26 @@ export default function ResourceBrowser({
       const ascending = sortDirection === 'asc';
       
       // Use fetchResourcesBySearch for keyword-specific filtering
-      const response = await fetchResourcesBySearch(
+      const { resources: raw, nextToken: newToken } = await fetchResourcesBySearch(
         keyword,
         activeSearch,
         ascending,
         sortBy,
         undefined, // author filter
-        page
+        paginationToken
       );
 
       // Extract resources from response
-      const raw = response || [];
       const normalized = raw.map(normalize);
 
-      if (page === 1 && replace) {
+      if (paginationToken === undefined && replace) {
         setResources(normalized);
       } else {
         setResources((prev) => [...prev.filter((r) => !r.isPlaceholder), ...normalized]);
       }
 
-      setHasMore(raw.length === pageSize);
+      setHasMore(!!newToken);
+      setNextToken(newToken);
       setLoading(false);
 
       // Lazy metadata enrichment
@@ -118,10 +118,10 @@ export default function ResourceBrowser({
 
   // Reset + fetch whenever filters change
   useEffect(() => {
-    setCurrentPage(1);
+    setNextToken(undefined);
     setHasMore(true);
     fetchingRef.current = false;
-    fetchPage(1, true);
+    fetchPage(undefined, true);
   }, [keyword, activeSearch, sortBy, sortDirection, fetchPage]);
 
   // Infinite scroll
@@ -130,14 +130,12 @@ export default function ResourceBrowser({
       if (fetchingRef.current || !hasMore || loading) return;
       const { scrollTop, clientHeight, scrollHeight } = document.documentElement;
       if (scrollTop + clientHeight >= scrollHeight - scrollThreshold) {
-        const next = currentPage + 1;
-        setCurrentPage(next);
-        fetchPage(next);
+        fetchPage(nextToken);
       }
     };
     window.addEventListener('scroll', onScroll);
     return () => window.removeEventListener('scroll', onScroll);
-  }, [currentPage, hasMore, loading, fetchPage, scrollThreshold]);
+  }, [nextToken, hasMore, loading, fetchPage, scrollThreshold]);
 
   // Debounced search
   const handleSearchChange = (val) => {

--- a/src/components/ResourceBrowser/index.js
+++ b/src/components/ResourceBrowser/index.js
@@ -61,11 +61,11 @@ export default function ResourceBrowser({
     fetchingRef.current = true;
 
     try {
-      if (page === 1 && replace) {
+      if (paginationToken === undefined && replace) {
         setResources(createPlaceholders());
         setLoading(true);
-      } else if (page > 1) {
-        setResources((prev) => [...prev, ...createPlaceholders(pageSize, page)]);
+      } else if (paginationToken !== undefined) {
+        setResources((prev) => [...prev, ...createPlaceholders(pageSize, Date.now())]);
       }
 
       const ascending = sortDirection === 'asc';


### PR DESCRIPTION
CIROH Hub was leveraging an internal search API endpoint that is being removed.  This PR updates the app to use the newer, public search API endpoint `/hsapi/discovery-atlas/search`.  Changes were required to support the token-based pagination that the new endpoint uses.  Also removed some duplicated code that was unused (seemed to be part of an incomplete refactor).

Note: I used Copilot for some AI assistance when writing this PR to help in an unfamiliar codebase but any code that I did not write was reviewed, understood, and tested by me.

## Additions

- No new code introduced -- just refactoring and removing duplicated code

## Removals

- Code that was duplicated in both `hydroshareAPI.js` and `HydroShareImporter/index.js` was moved to just `hydroshareAPI.js` as the source of truth for API interactions.  `HydroShareImporter/index.js` now imports from there.

## Changes 

- Uses public search API endpoint and the query param names that it expects
- Switched to token-based pagination (use `paginationToken` returned on last item in results to get next page of results) instead of page-based (increment page number to get the next page)

## Testing

1. Tested by running the app locally and was able to data returned and displayed on the  datasets/apps/notebooks/presentations/courses pages.  The data returned by the legacy endpoint was stale so slight differences are expected.

## Screenshots

Datasets page in prod:
<img width="1301" height="843" alt="Screenshot 2026-06-05 at 9 39 56 AM" src="https://github.com/user-attachments/assets/366c0e06-8ac8-4045-b017-2283388739bd" />

Datasets page tested locally:
<img width="1301" height="845" alt="Screenshot 2026-06-05 at 9 39 47 AM" src="https://github.com/user-attachments/assets/0cd8f849-22b4-4948-9db3-31b11006647f" />

Notebooks page in prod:
<img width="1304" height="845" alt="Screenshot 2026-06-05 at 9 40 21 AM" src="https://github.com/user-attachments/assets/15b01e73-613f-4748-94ea-b9e9fad4031c" />

Notebooks page tested locally:
<img width="1309" height="842" alt="Screenshot 2026-06-05 at 9 40 13 AM" src="https://github.com/user-attachments/assets/6f55b487-b54b-49e4-b07c-08c49bd0d25f" />

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests -- note: there are no tests
- [x] Any _change_ in functionality is tested -- tested manually by running app locally
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows -- this is a UI change only, not tested across different OS
- [ ] Linux
- [x] Browser

### Accessibility

- [x] Keyboard friendly
- [x] Screen reader friendly

### Other

- [ ] Is useable without CSS -- unsure what this means
- [ ] Is useable without JS -- unsure what this means
- [x] Flexible from small to large screens -- no visual changes
- [x] No linting errors or warnings
- [x] JavaScript tests are passing -- none
