### PR TITLE
Fix broken NWM BigQuery API request form link

### DIFF
--- a/docs/products/data-management/bigquery-api/index.mdx
+++ b/docs/products/data-management/bigquery-api/index.mdx
@@ -18,7 +18,7 @@ More details about “Design and implementation of a BigQuery dataset and applic
 # Steps to use CIROH NWM API
 1. Submit the form below to request access to [NWM BigQuery API](https://nwm-api.ciroh.org/).
 
-<Link class="button button--active button--primary " style={{'margin-bottom':'1.3rem'}} href="https://github.com/CIROH-UA/NGIAB-CloudInfra/issues/new?assignees=&labels=infrastructure&projects=&template=case_studies_call.md&title=">NWM BigQuery API Access Request Form</Link>
+<Link class="button button--active button--primary " style={{'margin-bottom':'1.3rem'}} href="https://github.com/CIROH-UA/NGIAB-CloudInfra/issues/new?template=case_studies_call_template.yml">NWM BigQuery API Access Request Form</Link>
 
 2. For an example usage, please refer to [this script](https://github.com/CIROH-UA/api-nwm-gcp/blob/main/examples/notebooks/nwm_usgs_streamflow_plot.ipynb). Replace your API key and API_URL = 'https://nwm-api.ciroh.org'.
 


### PR DESCRIPTION
Updates the NWM BigQuery request-form button to the current YAML template (case_studies_call_template.yml). The old link (case_studies_call.md) was removed in CIROH-UA/NGIAB-CloudInfra#443, so users currently get a blank issue (e.g. CIROH-UA/NGIAB-CloudInfra#488).