### PR TITLE
Wiki markdown rendering for 2i2c docs

### DIFF
--- a/docs/services/cloudservices/2i2c/available-images.mdx
+++ b/docs/services/cloudservices/2i2c/available-images.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 22
+sidebar_position: 03
 title: "List of Available Images"
 description: "Explore CIROH's available image configurations."
 tags: [CIROH, Services, Cloud Services, JupyterHub, 2i2c, Google Cloud, Education]
@@ -15,9 +15,6 @@ tags: [CIROH, Services, Cloud Services, JupyterHub, 2i2c, Google Cloud, Educatio
 
 Server image configurations are options for what software environment you want your Jupyter Notebook server to run in.
 
-A full listing of these images [can be found on the GitHub wiki]("https://github.com/CIROH-UA/awi-ciroh-image/wiki/2i2c-image-list").
+import GitHubWikiPage from '@site/src/components/GitHubHandling/GitHubWikiPage';
 
-{/* 
-    Note that as of June 2026, the GitHub REST API does not support markdown output of wiki pages.
-    If and when this feature is finally provided, the "GitHubWikiPage" component should provide full support.
-*/}
+<GitHubWikiPage username="CIROH-UA" repo="awi-ciroh-image" path="2i2c-image-list" />

--- a/docs/services/cloudservices/2i2c/custom-images.mdx
+++ b/docs/services/cloudservices/2i2c/custom-images.mdx
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 21
-title: "Custom Images"
+title: "Making Custom Images"
 description: "Request JupyterHub server images tailored to your needs."
 tags: [CIROH, Services, Cloud Services, JupyterHub, 2i2c, Google Cloud, Education]
 ---
@@ -15,7 +15,7 @@ tags: [CIROH, Services, Cloud Services, JupyterHub, 2i2c, Google Cloud, Educatio
 
 import GitHubReadme from '@site/src/components/GitHubHandling/GitHubReadme';
 
-<GitHubReadme username="ciroh-ua" repo="awi-ciroh-image" />
+<GitHubReadme username="CIROH-UA" repo="awi-ciroh-image" />
 
 
  

--- a/src/components/GitHubHandling/GitHubMarkdown.js
+++ b/src/components/GitHubHandling/GitHubMarkdown.js
@@ -82,7 +82,7 @@ function GitHubMarkdown({ apiUrl, srcUrl, cwdUrl, trimTitle = 'false' }) {
         })
             .then(response => {
                 if (!response.ok) {
-                    throw new Error('Failed to fetch README');
+                    throw new Error('Failed to fetch markdown');
                 }
                 return response.text();
             })
@@ -104,7 +104,7 @@ function GitHubMarkdown({ apiUrl, srcUrl, cwdUrl, trimTitle = 'false' }) {
                 // Update the state with the combined content
                 setMarkdownContent(combinedHtml);
             })
-            .catch(err => console.error('Error fetching README:', err));
+            .catch(err => console.error('Error fetching markdown:', err));
     }, [apiUrl, srcUrl, cwdUrl, trimTitle]);
 
     // Render the HTML content

--- a/src/components/GitHubHandling/GitHubWikiPage.js
+++ b/src/components/GitHubHandling/GitHubWikiPage.js
@@ -1,12 +1,48 @@
 import React, { useEffect, useState } from 'react';
 import GitHubMarkdown from './GitHubMarkdown'
+import MarkdownHooks from 'react-markdown'
 
-// Unfortunately, a feature request for this appears to have spent two years
-// untouched, so this is not currently something we can do.
-// It's highly desirable as a feature, though, so I've left the stub here in the meantime.
-// 
-// - Nia Minor, 06/12/2026
+// Unfortunately, the GitHub API doesn't support wiki pages.
+// As such, this has to use a unique client-side rendering codepath.
+// If the API ever adds this support, a simplified function is
+// provided at the bottom of this file.
+// - Nia Minor, 06/26/2026
 
+function GitHubWikiPage({ repo, username, path = 'home' }) {
+    const rawUrl = `https://raw.githubusercontent.com/wiki/${username}/${repo}/${path}.md`;
+    const prettyUrl = `https://github.com/${username}/${repo}/wiki/${path}`;
+    const [mdContent, setMdContent] = useState("");
+
+    useEffect(() => {
+        fetch(rawUrl, {
+            headers: {
+                Accept: 'application/vnd.github.v3.html',
+            },
+        })
+            .then(response => {
+                if (!response.ok) {
+                    throw new Error('Failed to fetch wiki page');
+                }
+                return response.text();
+            })
+            .then(md => {
+                setMdContent(md);
+            })
+            .catch(err => console.error('Error fetching markdown:', err));
+    }, [rawUrl]);
+
+    return <>
+        <blockquote style={{padding: "20px", fontSize: "1.1rem"}}>
+            <strong>NOTE</strong><br />
+            Below content is rendered from <a href={prettyUrl}>{prettyUrl}</a>.
+        </blockquote>
+        <MarkdownHooks>{mdContent}</MarkdownHooks>    
+    </>;
+}
+
+/*
+// Simplified function for if the GitHub API adds support for wiki pages.
+// This is preferred because it offloads MD rendering to GitHub's service.
 function GitHubWikiPage({ repo, username, path = 'home', trimTitle = 'false' }) {
     // Construct the GitHub API URL to fetch the wiki page as HTML
     const apiUrl = `api-url-here`;
@@ -17,5 +53,6 @@ function GitHubWikiPage({ repo, username, path = 'home', trimTitle = 'false' }) 
     //return <GitHubMarkdown apiUrl={apiUrl} srcUrl={srcUrl} cwdUrl={cwdUrl} trimTitle={trimTitle} />;
     return "Unsupported pending a GitHub API update. See https://github.com/orgs/community/discussions/102891#discussioncomment-8340473";
 }
+*/
 
 export default GitHubWikiPage;


### PR DESCRIPTION
Rendering from wiki is now working. Also, the image list has been moved up in the sidebar as requested.
<img width="1355" height="701" alt="image" src="https://github.com/user-attachments/assets/822d7343-c935-4d9c-8a44-2dc98ee7eba9" />
