### PR TITLE
Products: Add rs_route under NGIAB

### DIFF
--- a/docs/products/ngiab/community-nextgen-repos/lstm.mdx
+++ b/docs/products/ngiab/community-nextgen-repos/lstm.mdx
@@ -1,6 +1,6 @@
 ---
 title: lstm
-sidebar_position: 3
+sidebar_position: 4
 description: "Cutting edge neural network-based modeling, adapted and optimized for the BMI standard."
 tags: [National Water Model, NOAA, NGIAB, CIROH, AI and Machine Learning, NextGen]
 ---

--- a/docs/products/ngiab/community-nextgen-repos/rs_route.mdx
+++ b/docs/products/ngiab/community-nextgen-repos/rs_route.mdx
@@ -1,0 +1,10 @@
+---
+title: "rs_route"
+sidebar_position: 3
+description: "A Rust package for generating realistic and hydrologically consistent channel networks."
+tags: [National Water Model, NOAA, NGIAB, CIROH, NextGen]
+---
+
+import GitHubReadme from '@site/src/components/GitHubHandling/GitHubReadme';
+
+<GitHubReadme username="CIROH-UA" repo="rs_route" trimTitle="true" />

--- a/docs/products/ngiab/community-nextgen-repos/rust-lstm.mdx
+++ b/docs/products/ngiab/community-nextgen-repos/rust-lstm.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 4
+sidebar_position: 5
 title: "rust-lstm"
 description: "A Rust implementation of a BMI (Basic Model Interface) adapter for LSTM-based streamflow prediction."
 tags: [National Water Model, NOAA, NGIAB, CIROH, AI and Machine Learning, NextGen]


### PR DESCRIPTION
Title. The page simply consists of a GitHub README mirror.

<img width="1397" height="708" alt="image" src="https://github.com/user-attachments/assets/e768b5fe-61e3-45e7-b918-bf506725e564" />
