### PR TITLE
Fix publications collections selector visibility

### DIFF
--- a/src/components/Publications/SelectCollection.js
+++ b/src/components/Publications/SelectCollection.js
@@ -107,6 +107,7 @@ function SelectCollectionInner({zotero, onChange}) {
   const styles = useMemo(() => ({
     control:        s => ({...s, border:'1px solid #ccc'}),
     valueContainer: s => ({...s, padding:'2px 8px'}),
+    menuPortal:     s => ({...s, zIndex: 9999}),
     option: (base,state) => ({
       ...base,
       backgroundColor: state.isFocused

--- a/src/components/Publications/SelectCollection.js
+++ b/src/components/Publications/SelectCollection.js
@@ -111,12 +111,15 @@ function SelectCollectionInner({zotero, onChange}) {
     option: (base,state) => ({
       ...base,
       backgroundColor: state.isFocused
-        ? 'var(--ifm-color-primary-lightest)'
+        ? 'var(--ifm-color-primary)'
         : base.backgroundColor,
       color: state.isFocused
-        ? 'var(--ifm-color-primary-dark)'
+        ? 'var(--ifm-color-white)'
         : base.color,
-      ...(state.isSelected && {background:'var(--ifm-color-primary-lighter)'}),
+      ...(state.isSelected && {
+        backgroundColor: 'var(--ifm-color-primary)',
+        color: 'var(--ifm-color-white)',
+      }),
     }),
   }), [colorMode]);
 


### PR DESCRIPTION
- Fix the collections selector on the publications page so its options are visible — the dropdown menu was rendering behind other page content because its portal z-index was too low
- Fix the selector's styling so text on hovered and selected options is legible (previously it matched the background color and disappeared).

Resolves #144

<img width="1870" height="901" alt="image" src="https://github.com/user-attachments/assets/8e2332d9-706a-4f3b-8c28-bff0ee56fc97" />


<img width="1897" height="896" alt="image" src="https://github.com/user-attachments/assets/3ae1e292-ecb1-4d1f-b178-b6128d1acb66" />
