### PR TITLE
Use named profile for backend production deployment

### DIFF
--- a/.github/workflows/cd_deploy_backend.yml
+++ b/.github/workflows/cd_deploy_backend.yml
@@ -40,7 +40,7 @@ jobs:
       - name: SAM deploy
         run: |
           sam deploy \
-            --stack-name ${{ vars.AWS_STACK_NAME }} \
+            --config-env production \
             --capabilities CAPABILITY_IAM \
             --s3-bucket ${{ secrets.AWS_ARTIFACTS_BUCKET }} \
             --role-arn ${{ secrets.AWS_CLOUDFORMATION_EXECUTION_ROLE }} \

--- a/ciroh-hub-backend/samconfig.toml
+++ b/ciroh-hub-backend/samconfig.toml
@@ -28,3 +28,10 @@ warm_containers = "EAGER"
 
 [default.local_start_lambda.parameters]
 warm_containers = "EAGER"
+
+[production.global.parameters]
+stack_name = "CIROHHub-Backend"
+
+[production.deploy.parameters]
+capabilities = "CAPABILITY_IAM"
+confirm_changeset = false


### PR DESCRIPTION
The workflow's explicit `--s3-bucket` argument conflicted with `samconfig.toml`'s `resolve_s3 = true` default, causing `sam deploy` to error out.

Add a new `production` named profile to `samconfig.toml` that omits `resolve_s3`. The workflow now uses `--config-env production` to select it. The existing `default` profile is preserved for local dev with `resolve_s3 = true` intact.