### PR TITLE
Fix reCAPTCHA and Zotero key handling; improve form error visibility

### DIFF
--- a/.github/workflows/cd_deploy_backend.yml
+++ b/.github/workflows/cd_deploy_backend.yml
@@ -51,5 +51,5 @@ jobs:
               AllowedOrigin=https://hub.ciroh.org \
               AllowedRecaptchaHosts=hub.ciroh.org \
               RecaptchaSecretKey=${{ secrets.RECAPTCHA_SECRET_KEY }} \
-              ZoteroApiKey=${{ secrets.ZOTERO_API_KEY }} \
+              ZoteroApiKey=${{ secrets.ZOTERO_API_KEY_READ_WRITE }} \
               ZoteroStagingGroupId=${{ secrets.ZOTERO_CIROH_STAGING_GROUP_ID }}

--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -97,9 +97,8 @@ jobs:
     - name: Build website
       run: npm run build
       env:
-          ZOTERO_API_KEY: ${{ secrets.ZOTERO_API_KEY }}
+          ZOTERO_API_KEY_READ_ONLY: ${{ secrets.ZOTERO_API_KEY_READ_ONLY }}
           ZOTERO_CIROH_GROUP_ID: ${{ secrets.ZOTERO_CIROH_GROUP_ID }}
-          ZOTERO_STAGING_API_KEY: ${{ secrets.ZOTERO_STAGING_API_KEY }}
           ZOTERO_CIROH_STAGING_GROUP_ID: ${{ secrets.ZOTERO_CIROH_STAGING_GROUP_ID }}
           ZOTERO_IMPORT_REQUEST_API_URL: ${{ vars.ZOTERO_IMPORT_REQUEST_API_URL }}
           RECAPTCHA_SITE_KEY: ${{ vars.RECAPTCHA_SITE_KEY }}

--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -102,7 +102,7 @@ jobs:
           ZOTERO_STAGING_API_KEY: ${{ secrets.ZOTERO_STAGING_API_KEY }}
           ZOTERO_CIROH_STAGING_GROUP_ID: ${{ secrets.ZOTERO_CIROH_STAGING_GROUP_ID }}
           ZOTERO_IMPORT_REQUEST_API_URL: ${{ vars.ZOTERO_IMPORT_REQUEST_API_URL }}
-          RECAPTCHA_SECRET_KEY: ${{ secrets.RECAPTCHA_SECRET_KEY }}
+          RECAPTCHA_SITE_KEY: ${{ vars.RECAPTCHA_SITE_KEY }}
           S3_BUCKET_NAME: ${{ secrets.S3_BUCKET_NAME }}
           S3_ACCESS_KEY: ${{ secrets.S3_ACCESS_KEY }}
           S3_SECRET_KEY: ${{ secrets.S3_SECRET_KEY }}

--- a/ciroh-hub-backend/README.md
+++ b/ciroh-hub-backend/README.md
@@ -30,7 +30,7 @@ The Lambda needs several environment variables. Create a file `env.json` in this
     "ALLOWED_ORIGIN": "http://localhost:3001",
     "RECAPTCHA_SECRET_KEY": "your_recaptcha_secret_key",
     "RECAPTCHA_ALLOWED_HOSTS": "localhost,hub.ciroh.org",
-    "ZOTERO_API_KEY": "your_zotero_write_key",
+    "ZOTERO_API_KEY_READ_WRITE": "your_zotero_write_key",
     "ZOTERO_STAGING_GROUP_ID": "5943481"
   }
 }

--- a/ciroh-hub-backend/template.yaml
+++ b/ciroh-hub-backend/template.yaml
@@ -73,7 +73,7 @@ Resources:
           ALLOWED_ORIGIN: !Ref AllowedOrigin
           RECAPTCHA_ALLOWED_HOSTS: !Ref AllowedRecaptchaHosts
           RECAPTCHA_SECRET_KEY: !Ref RecaptchaSecretKey
-          ZOTERO_API_KEY: !Ref ZoteroApiKey
+          ZOTERO_API_KEY_READ_WRITE: !Ref ZoteroApiKey
           ZOTERO_STAGING_GROUP_ID: !Ref ZoteroStagingGroupId
 
 

--- a/ciroh-hub-backend/zotero-import-request/app.mjs
+++ b/ciroh-hub-backend/zotero-import-request/app.mjs
@@ -34,7 +34,7 @@ async function importCitationIntoZotero(
 ) {
   try {
     // Initialize the client with your API key and configure for the group library.
-    const apiKey = process.env.ZOTERO_API_KEY;
+    const apiKey = process.env.ZOTERO_API_KEY_READ_WRITE;
     const groupId = process.env.ZOTERO_STAGING_GROUP_ID;
     const zotero = api(apiKey).library('group', groupId);
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -87,7 +87,7 @@ const config = {
     zotero_api_key: process.env.ZOTERO_API_KEY || "dummy",
     zotero_group_id: process.env.ZOTERO_CIROH_GROUP_ID || 999999999,
     zotero_staging_group_id: process.env.ZOTERO_CIROH_STAGING_GROUP_ID,
-    captcha_key: process.env.RECAPTCHA_SECRET_KEY || "dummy",
+    recaptcha_site_key: process.env.RECAPTCHA_SITE_KEY || "dummy",
     zotero_import_request_api_url: process.env.ZOTERO_IMPORT_REQUEST_API_URL || "http://127.0.0.1:3000/zotero-import-request",
     s3_bucket: process.env.S3_BUCKET_NAME,
     s3_access_key: process.env.S3_ACCESS_KEY,

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -84,7 +84,7 @@ const config = {
       },
 
     ],
-    zotero_api_key: process.env.ZOTERO_API_KEY || "dummy",
+    zotero_api_key_read_only: process.env.ZOTERO_API_KEY_READ_ONLY || "dummy",
     zotero_group_id: process.env.ZOTERO_CIROH_GROUP_ID || 999999999,
     zotero_staging_group_id: process.env.ZOTERO_CIROH_STAGING_GROUP_ID,
     recaptcha_site_key: process.env.RECAPTCHA_SITE_KEY || "dummy",

--- a/src/components/HomepageFeatures/ResearchFeature/index.js
+++ b/src/components/HomepageFeatures/ResearchFeature/index.js
@@ -9,7 +9,7 @@ export default function ResearchFeature() {
 
     // ---------- ZOTERO API HANDLING ----------
     const { siteConfig } = useDocusaurusContext();
-    const zotero_api_key = siteConfig.customFields.zotero_api_key;
+    const zotero_api_key = siteConfig.customFields.zotero_api_key_read_only;
     const zotero_group_id = siteConfig.customFields.zotero_group_id;
 
     // Count total publications in the configured Zotero group library.

--- a/src/components/PublicationsSubmissionForm/index.js
+++ b/src/components/PublicationsSubmissionForm/index.js
@@ -210,6 +210,7 @@ export default function PublicationsSubmissionForm({ groupId, zoteroApiKey }) {
       setProgressMessage('Citation imported successfully! Visit your citation ');
     } catch (err) {
       setError(err.message);
+      setProgressMessage(err.message);
       console.log(err);
     } finally {
       setLoading(false);
@@ -373,7 +374,7 @@ export default function PublicationsSubmissionForm({ groupId, zoteroApiKey }) {
         </div>
       )}
       {progressMessage && (
-        <div className={styles.progressMessage}>
+        <div className={clsx(styles.progressMessage, error && styles.errorMessage)}>
           {loading && <FaSpinner className={styles.spinner} />}
           <span>
             {progressMessage}

--- a/src/components/PublicationsSubmissionForm/index.js
+++ b/src/components/PublicationsSubmissionForm/index.js
@@ -348,7 +348,7 @@ export default function PublicationsSubmissionForm({ groupId, zoteroApiKey }) {
           <ReCAPTCHA
             key={colorMode}
             ref={recaptchaRef}
-            sitekey={customFields.captcha_key}
+            sitekey={customFields.recaptcha_site_key}
             onChange={handleRecaptcha}
             theme={colorMode === 'dark' ? 'dark' : 'light'}
           />

--- a/src/pages/contribute/index.js
+++ b/src/pages/contribute/index.js
@@ -27,7 +27,7 @@ function ContributeContent() {
   const contactUrl = useBaseUrl('/contact');
   const zoteroLogin = siteConfig?.customFields?.externalLinks?.zoteroLogin || 'https://www.zotero.org/user/login';
   const zoteroGroupId = siteConfig?.customFields?.zotero_staging_group_id;
-  const zoteroApiKey = siteConfig?.customFields?.zotero_api_key;
+  const zoteroApiKey = siteConfig?.customFields?.zotero_api_key_read_only;
 
   const tethysDevelopUrl = useBaseUrl('/contribute/develop');
   const feedbackUrl = siteConfig?.customFields?.externalLinks?.feedbackForm || 'https://forms.cloud.microsoft/r/NzA2sLrzeJ';

--- a/src/pages/publications/index.js
+++ b/src/pages/publications/index.js
@@ -44,7 +44,7 @@ export default function PublicationsPage() {
       <main className="tw-relative tw-z-20">
         
        <Publications 
-          apiKey={siteConfig.customFields.zotero_api_key}
+          apiKey={siteConfig.customFields.zotero_api_key_read_only}
           groupId={siteConfig.customFields.zotero_group_id}
        />
        <TechBox items={items} type={"Publications"}  />


### PR DESCRIPTION
Use reCAPTCHA site key in frontend

- The frontend build was mistakenly reading RECAPTCHA_SECRET_KEY,
  embedding whatever it held into the public site as the widget's
  sitekey
- Read RECAPTCHA_SITE_KEY from a GitHub variable instead of a secret;
  site keys are public by design, and a visible variable makes it
  easy to verify the right key is configured
- Rename captcha_key to recaptcha_site_key in customFields for more
  specificity to avoid confusion

Use separate Zotero API keys for frontend and backend

- The frontend and backend were using the same API key, resulting in
  the write-access key needed by the backend being embedded in the
  public frontend bundle
- Frontend now uses a read-only key (`ZOTERO_API_KEY_READ_ONLY`) for
  listing publications and collections; the backend Lambda uses a
  separate write key (`ZOTERO_API_KEY_READ_WRITE`)
- Update environment variable names to make each key's privilege
  level explicit

Show errors below PublicationsSubmissionForm component

- Errors only appeared above the form, while the text below the form
  kept showing "Importing Citation..." even after a failure
- The form is too tall to see the error text at the top when viewing
  the submit button, so failures looked like they were still in
  progress
- The error message now also appears below the form in error styling,
  where the user is looking after submitting