### PR TITLE
Add subject/keyword filter to HydroShareResourcesSelector

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,6 @@
         "docusaurus-plugin-drawio": "^0.4.0",
         "dotenv": "^17.2.3",
         "express": "^5.2.1",
-        "fast-xml-parser": "^5.5.1",
         "gsap": "^3.14.2",
         "lenis": "^1.3.15",
         "lunr": "^2.3.9",
@@ -14017,41 +14016,6 @@
       ],
       "license": "BSD-3-Clause"
     },
-    "node_modules/fast-xml-builder": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.0.tgz",
-      "integrity": "sha512-7mtITW/we2/wTUZqMyBOR2F8xP4CRxMiSEcQxPIqdRWdO2L/HZSOlzoNyghmyDwNB8BDxePooV1ZTJpkOUhdRg==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "path-expression-matcher": "^1.1.2"
-      }
-    },
-    "node_modules/fast-xml-parser": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.1.tgz",
-      "integrity": "sha512-JTpMz8P5mDoNYzXTmTT/xzWjFiCWi0U+UQTJtrFH9muXsr2RqtXZPbnCW5h2mKsOd4u3XcPWCvDSrnaBPlUcMQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "fast-xml-builder": "^1.1.0",
-        "path-expression-matcher": "^1.1.2",
-        "strnum": "^2.1.2"
-      },
-      "bin": {
-        "fxparser": "src/cli/cli.js"
-      }
-    },
     "node_modules/fastq": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
@@ -22945,21 +22909,6 @@
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
-    "node_modules/path-expression-matcher": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.1.2.tgz",
-      "integrity": "sha512-LXWqJmcpp2BKOEmgt4CyuESFmBfPuhJlAHKJsFzuJU6CxErWk75BrO+Ni77M9OxHN6dCYKM4vj+21Z6cOL96YQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -28179,18 +28128,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/strnum": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.0.tgz",
-      "integrity": "sha512-Y7Bj8XyJxnPAORMZj/xltsfo55uOiyHcU2tnAVzHUnSJR/KsEX+9RoDeXEnsXtl/CX4fAcrt64gZ13aGaWPeBg==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT"
     },
     "node_modules/style-to-js": {
       "version": "1.1.21",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "docusaurus-plugin-drawio": "^0.4.0",
     "dotenv": "^17.2.3",
     "express": "^5.2.1",
-    "fast-xml-parser": "^5.5.1",
     "gsap": "^3.14.2",
     "lenis": "^1.3.15",
     "lunr": "^2.3.9",

--- a/src/components/HydroShareImporter/index.js
+++ b/src/components/HydroShareImporter/index.js
@@ -150,8 +150,27 @@ function getRawDiscoveryResources(data) {
 // }
 
 async function fetchResource(id) {
-  const url = `https://www.hydroshare.org/hsapi/resource/${encodeURIComponent(id)}/sysmeta`;
-  return fetchJson(url, "resources");
+  // Fetch the resource from HydroShare
+  const url = `https://www.hydroshare.org/hsapi/resource/${encodeURIComponent(id)}/scimeta/elements/`;
+  const response = await fetchJson(url, `scimeta elements for resource ${id}`);
+
+  // Extract identifiers and other relevant fields from the response
+  const identifiers = response.identifiers || [];
+  const hydroShareUrl = identifiers.find(i => i.name === 'hydroShareIdentifier')?.url;
+  const dates = response.dates || [];
+
+  return {
+    resource_id: id,
+    resource_title: response.title || "",
+    authors: (response.creators || []).map(c => c.name || c.organization || "").filter(Boolean),
+    resource_type: typeof response.type === 'string' ? response.type.replace(/^.*\//, "") : "", // Extract the last segment of the URI (http://www.hydroshare.org/terms/CollectionResource - > CollectionResource)
+    resource_url: hydroShareUrl || `https://www.hydroshare.org/resource/${id}/`,
+    doi: identifiers.find(i => i.name === 'doi')?.url || null,
+    abstract: response.description || "",
+    date_created: dates.find(d => d.type === 'created')?.start_date || "",
+    date_last_updated: dates.find(d => d.type === 'modified')?.start_date || "",
+    subjects: (response.subjects || []).map(s => s?.value).filter(Boolean),
+  };
 }
 
 // Helper function to fetch list of resources by group

--- a/src/components/HydroShareImporter/index.js
+++ b/src/components/HydroShareImporter/index.js
@@ -1,4 +1,7 @@
-const { XMLParser } = require("fast-xml-parser");
+// Matches HydroShare resource ids contained in the relations, which can be in the form of:
+//   .../resource/<32-hex>
+//   https://doi.org/10.4211/hs.<32-hex>
+const RESOURCE_ID_REGEX = /(?:\/resource\/|10\.4211\/hs\.)([0-9a-f]{32})/i;
 
 /**
  * Sample endpoint: 
@@ -544,7 +547,7 @@ async function fetchRawCuratedResources(curated_parent_id) {
  */
 async function fetchResourcesFromCollection(collectionId) {
   // Fetch the collection metadata to extract its contained resource ids
-  const collectionMetadataUrl = `https://www.hydroshare.org/hsapi/resource/${collectionId}/scimeta/`;
+  const collectionMetadataUrl = `https://www.hydroshare.org/hsapi/resource/${collectionId}/scimeta/elements/`;
   const collectionMetadataResponse = await fetch(collectionMetadataUrl);
 
   // Error occurred
@@ -552,30 +555,36 @@ async function fetchResourcesFromCollection(collectionId) {
     throw new Error(`Error fetching collection metadata for ${collectionId} (status: ${collectionMetadataResponse.status})`);
   }
 
-  // Parse the XML metadata to extract resource ids
-  const collectionMetadataText = await collectionMetadataResponse.text();
-  const xmlParser = new XMLParser();
-  const collectionMetadata = xmlParser.parse(collectionMetadataText);
+  // Get the response data as JSON
+  const collectionMetadataJson = await collectionMetadataResponse.json();
 
-  // Get the relations as an array (handle both single relation and multiple relations cases)
-  const relations = collectionMetadata['rdf:RDF']['hsterms:CollectionResource']['dc:relation'];
-  const relationsList = Array.isArray(relations) ? relations : [relations];
+  // Get the relations of the collection (if available) to find the contained resources
+  const relations = collectionMetadataJson.relations || [];
 
   // Extract each resource id from the collection relations
-  const resourceIds = [];
-  for (const relation of relationsList)
+  const resourceIds = new Set();
+  for (const relation of relations)
   {
     // Extract resource id
-    const hasPartText = relation['rdf:Description']['dcterms:hasPart']
-    const url = hasPartText.split(' ').pop();
-    const resourceId = url.split('/').pop();
-    
-    // Add resource id to list
-    resourceIds.push(resourceId);
+    if (relation.type === 'hasPart' && relation.value)
+    {
+      // Extract the resource id from the relation
+      const match = relation.value.match(RESOURCE_ID_REGEX);
+
+      if (match)
+      {
+        // Add resource id to list
+        resourceIds.add(match[1].toLowerCase());
+      }
+      else
+      {
+        console.warn(`Unrecognized hasPart relation in collection ${collectionId}: ${relation.value}`);
+      }
+    }
   }
 
   // Fetch all resources in parallel
-  const resourcePromises = resourceIds.map(resourceId =>
+  const resourcePromises = Array.from(resourceIds).map(resourceId =>
     fetchResource(resourceId).catch(err => {
       console.error(`Error fetching resource ${resourceId} from collection ${collectionId}:`, err);
       return null;

--- a/src/components/HydroShareResourcesSelector/index.js
+++ b/src/components/HydroShareResourcesSelector/index.js
@@ -405,53 +405,73 @@ export default function HydroShareResourcesSelector({
             </div>
 
             <form
-              className="tw-flex tw-flex-col md:tw-flex-row md:tw-items-center tw-gap-3 tw-w-full lg:tw-w-auto"
+              className="tw-flex tw-flex-col md:tw-flex-row md:tw-items-end tw-gap-3 tw-w-full lg:tw-w-auto"
               onSubmit={e => { e.preventDefault(); commitSearch(searchInput); }}
             >
-              <div className="tw-relative tw-w-full md:tw-w-[28rem]">
-                <span className="tw-pointer-events-none tw-absolute tw-left-3 tw-inset-y-0 tw-flex tw-items-center tw-text-slate-400 dark:tw-text-slate-500">
-                  <HiOutlineSearch size={18} />
+              {/* Search Input */}
+              <label className="tw-flex tw-flex-col tw-w-full md:tw-w-[28rem]">
+                <span className="tw-mb-1 tw-text-sm tw-font-semibold tw-text-slate-600 dark:tw-text-slate-300">
+                  Search
                 </span>
-                <input
-                  type="text"
-                  placeholder="Search by Title, Author, Description..."
-                  className="tw-w-full tw-rounded-lg tw-border tw-border-slate-200/80 dark:tw-border-slate-700/80 tw-bg-white/80 dark:tw-bg-slate-900/50 tw-backdrop-blur tw-pl-10 tw-pr-3 tw-py-3 tw-text-sm tw-text-slate-900 dark:tw-text-white placeholder:tw-text-slate-400 dark:placeholder:tw-text-slate-500 focus:tw-outline-none focus:tw-ring-2 focus:tw-ring-cyan-500/30"
-                  value={searchInput}
-                  onChange={e => setSearchInput(e.target.value)}
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter') {
-                      e.preventDefault();
-                      commitSearch(e.currentTarget.value);
-                    }
-                  }}
-                  onBlur={(e) => commitSearch(e.currentTarget.value)}
-                />
-              </div>
-
+                <div className="tw-relative">
+                  <span className="tw-pointer-events-none tw-absolute tw-left-3 tw-inset-y-0 tw-flex tw-items-center tw-text-slate-400 dark:tw-text-slate-500">
+                    <HiOutlineSearch size={18} />
+                  </span>
+                  <input
+                    type="text"
+                    placeholder="Search by Title, Author, Description..."
+                    className="tw-w-full tw-rounded-lg tw-border tw-border-slate-200/80 dark:tw-border-slate-700/80 tw-bg-white/80 dark:tw-bg-slate-900/50 tw-backdrop-blur tw-pl-10 tw-pr-3 tw-py-3 tw-text-sm tw-text-slate-900 dark:tw-text-white placeholder:tw-text-slate-400 dark:placeholder:tw-text-slate-500 focus:tw-outline-none focus:tw-ring-2 focus:tw-ring-cyan-500/30"
+                    value={searchInput}
+                    onChange={e => setSearchInput(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') {
+                        e.preventDefault();
+                        commitSearch(e.currentTarget.value);
+                      }
+                    }}
+                    onBlur={(e) => commitSearch(e.currentTarget.value)}
+                  />
+                </div>
+              </label>
+              
+              {/* Group Selector */}
               <div className="tw-flex tw-flex-wrap tw-gap-2 tw-items-center">
-                <select
-                  value={ecosystem}
-                  onChange={e => setEcosystem(e.target.value)}
-                  className="tw-rounded-lg tw-border tw-border-slate-200/80 dark:tw-border-slate-700/80 tw-bg-white/80 dark:tw-bg-slate-900/50 tw-backdrop-blur tw-px-3 tw-py-3 tw-text-sm tw-text-slate-900 dark:tw-text-white focus:tw-outline-none focus:tw-ring-2 focus:tw-ring-cyan-500/30"
-                >
-                  {ecosystems.map(({name, id}) => (
-                    <option key={id} value={id}>{name}</option>
-                  ))}
-                </select>
+                <label className="tw-flex tw-flex-col">
+                  <span className="tw-mb-1 tw-text-sm tw-font-semibold tw-text-slate-600 dark:tw-text-slate-300">
+                    Group
+                  </span>
+                  <select
+                    value={ecosystem}
+                    onChange={e => setEcosystem(e.target.value)}
+                    className="tw-rounded-lg tw-border tw-border-slate-200/80 dark:tw-border-slate-700/80 tw-bg-white/80 dark:tw-bg-slate-900/50 tw-backdrop-blur tw-px-3 tw-py-3 tw-text-sm tw-text-slate-900 dark:tw-text-white focus:tw-outline-none focus:tw-ring-2 focus:tw-ring-cyan-500/30"
+                  >
+                    {ecosystems.map(({name, id}) => (
+                      <option key={id} value={id}>{name}</option>
+                    ))}
+                  </select>
+                </label>
               </div>
-
-              <div className="tw-flex tw-flex-wrap tw-gap-2 tw-items-center">
-                <select
-                  value={sortType}
-                  onChange={e => setSortType(e.target.value)}
-                  className="tw-rounded-lg tw-border tw-border-slate-200/80 dark:tw-border-slate-700/80 tw-bg-white/80 dark:tw-bg-slate-900/50 tw-backdrop-blur tw-px-3 tw-py-3 tw-text-sm tw-text-slate-900 dark:tw-text-white focus:tw-outline-none focus:tw-ring-2 focus:tw-ring-cyan-500/30"
-                >
-                  <option value="lastModified">Last Updated</option>
-                  <option value="dateCreated">Date Created</option>
-                  <option value="name">Title</option>
-                  <option value="creatorName">Authors</option>
-                </select>
-
+              
+              {/* Sort Inputs */}
+              <div className="tw-flex tw-flex-wrap tw-gap-2 tw-items-end">
+                {/* Sort By Selector */}
+                <label className="tw-flex tw-flex-col">
+                  <span className="tw-mb-1 tw-text-sm tw-font-semibold tw-text-slate-600 dark:tw-text-slate-300">
+                    Sort by
+                  </span>
+                  <select
+                    value={sortType}
+                    onChange={e => setSortType(e.target.value)}
+                    className="tw-rounded-lg tw-border tw-border-slate-200/80 dark:tw-border-slate-700/80 tw-bg-white/80 dark:tw-bg-slate-900/50 tw-backdrop-blur tw-px-3 tw-py-3 tw-text-sm tw-text-slate-900 dark:tw-text-white focus:tw-outline-none focus:tw-ring-2 focus:tw-ring-cyan-500/30"
+                  >
+                    <option value="lastModified">Last Updated</option>
+                    <option value="dateCreated">Date Created</option>
+                    <option value="name">Title</option>
+                    <option value="creatorName">Authors</option>
+                  </select>
+                </label>
+                
+                {/* Sort Direction Button */}
                 <button
                   type="button"
                   aria-label={`Sort direction ${sortDirection}`}
@@ -466,7 +486,8 @@ export default function HydroShareResourcesSelector({
                     ? <HiOutlineSortAscending size={20} />
                     : <HiOutlineSortDescending size={20} />}
                 </button>
-
+                
+                {/* View Toggle Buttons */}
                 <div className="tw-flex tw-gap-2">
                   {/* <button
                     type="button"

--- a/src/components/HydroShareResourcesSelector/index.js
+++ b/src/components/HydroShareResourcesSelector/index.js
@@ -281,7 +281,7 @@ export default function HydroShareResourcesSelector({
           if (!cancelled)
           {
             // Extract the titles from the ecosystem resources
-            let ecosystems = [{'name': 'Ecosystem', 'id': ''}];
+            let ecosystems = [{'name': 'All', 'id': ''}];
 
             for (let resource of ecosystemsResponse.resources) {
               if (resource?.resource_title && resource?.resource_id) {

--- a/src/components/HydroShareResourcesSelector/index.js
+++ b/src/components/HydroShareResourcesSelector/index.js
@@ -5,7 +5,7 @@ import styles from "./styles.module.css";
 import HydroShareResourcesTiles from "@site/src/components/HydroShareResourcesTiles";
 import HydroShareResourcesRows from "@site/src/components/HydroShareResourcesRows";
 import HydroShareResourcesCards from "@site/src/components/HydroShareResourcesCards";
-import { fetchResourcesBySearch, fetchResourceCustomMetadata, getCommunityResources, fetchResourcesFromCollection } from "@site/src/components/HydroShareImporter";
+import { fetchResourcesBySearch, fetchResourceCustomMetadata, getCommunityResources, fetchResourcesFromCollection, fetchResourceMetadata } from "@site/src/components/HydroShareImporter";
 import {
   HiOutlineSortDescending,
   HiOutlineSortAscending,
@@ -170,13 +170,14 @@ export default function HydroShareResourcesSelector({
           description: res.abstract || "No description available.",
           date_created: res.date_created,
           date_last_updated: res.date_last_updated,
+          keywords: res.subjects,
           thumbnail_url: "",
           page_url: "",
           docs_url: "",
           embed_url: "",
         }));
 
-        // Search locally when ecosystem is selected
+        // Search and filter locally when ecosystem is selected
         if (ecosystemSelected) {
           const searchTerm = filterSearch.trim().toLowerCase();
           if (searchTerm) {
@@ -186,6 +187,12 @@ export default function HydroShareResourcesSelector({
               resource.description?.toLowerCase().includes(searchTerm)
             );
           }
+
+          // Keep only resources tagged with one of the current page's keywords (e.g. "ciroh_hub_app")
+          const pageKeywords = new Set(keyword.split(',').map(k => k.trim().toLowerCase()).filter(Boolean));
+          mappedList = mappedList.filter(resource =>
+            resource.keywords?.some(k => pageKeywords.has(k.trim().toLowerCase()))
+          );
         }
 
         // Sort locally when fetching datasets (or an ecosystem) to account for curated resources being combined with searched resources
@@ -219,12 +226,24 @@ export default function HydroShareResourcesSelector({
             const customMetadata = await fetchResourceCustomMetadata(res.resource_id);
             let embedUrl = "";
             if (customMetadata?.pres_path) embedUrl = `https://www.hydroshare.org/resource/${res.resource_id}/data/contents/${customMetadata.pres_path}`;
+            // Extract keywords/subjects from metadata, unless the resource already has them
+            let keywords = res.keywords;
+            if (!keywords) {
+              const metadata = await fetchResourceMetadata(res.resource_id);
+              keywords = [];
+              if (metadata?.subjects) {
+                for (let subject of metadata.subjects) {
+                  if (subject?.value) keywords.push(subject.value);
+                }
+              }
+            }
             const updatedResource = {
               ...res,
               thumbnail_url: customMetadata?.thumbnail_url || "",
               page_url: customMetadata?.page_url || "",
               docs_url: customMetadata?.docs_url || "",
               embed_url: embedUrl,
+              keywords: keywords,
             };
 
             setResources((current) =>
@@ -486,7 +505,7 @@ export default function HydroShareResourcesSelector({
             <CardsComponent resources={resources} defaultImage={defaultImage} />
           )}
 
-          {!loading && nonPlaceholderResources.length === 0 && (
+          {!loading && !fetching.current && nonPlaceholderResources.length === 0 && (
             <p className="tw-mt-10 tw-text-center tw-text-sm tw-text-slate-600 dark:tw-text-slate-300">
               No {resultLabel} Found
             </p>
@@ -595,7 +614,7 @@ export default function HydroShareResourcesSelector({
         )}
 
         {/* empty */}
-        {!loading && nonPlaceholderResources.length === 0 && (
+        {!loading && !fetching.current && nonPlaceholderResources.length === 0 && (
           <p className={styles.emptyMessage}>No&nbsp;Resources&nbsp;Found</p>
         )}
       </div>

--- a/src/components/HydroShareResourcesSelector/index.js
+++ b/src/components/HydroShareResourcesSelector/index.js
@@ -5,7 +5,7 @@ import styles from "./styles.module.css";
 import HydroShareResourcesTiles from "@site/src/components/HydroShareResourcesTiles";
 import HydroShareResourcesRows from "@site/src/components/HydroShareResourcesRows";
 import HydroShareResourcesCards from "@site/src/components/HydroShareResourcesCards";
-import { fetchResourcesBySearch, fetchResourceCustomMetadata, getCommunityResources } from "@site/src/components/HydroShareImporter";
+import { fetchResourcesBySearch, fetchResourceCustomMetadata, getCommunityResources, fetchResourcesFromCollection } from "@site/src/components/HydroShareImporter";
 import {
   HiOutlineSortDescending,
   HiOutlineSortAscending,
@@ -90,7 +90,8 @@ export default function HydroShareResourcesSelector({
   const [filterSearch,   setFilterSearch]   = useState('');
   const [sortType,       setSortType]       = useState('lastModified');
   const [sortDirection,  setSortDirection]  = useState('desc');
-
+  const [ecosystems, setEcosystems] = useState([]);
+  const [ecosystem, setEcosystem] = useState('');
 
 
   const fetchResources = useCallback(
@@ -134,6 +135,15 @@ export default function HydroShareResourcesSelector({
         // For datasets, use getCommunityResources which combines group and keyword resources
         let communityResponse = null;
         let searchResponse = null;
+        const ecosystemSelected = Boolean(ecosystem);
+
+        if (ecosystemSelected) {
+          // Fetch resources from the selected ecosystem collection
+          searchResponse = await fetchResourcesFromCollection(ecosystem) || [];
+          resourceList = searchResponse;
+          searchTokenRef.current = searchResponse?.nextPaginationToken;
+        }
+        else
         if (keyword.includes('data')) {
           // Fetch resources using the community endpoint which handles both group and keyword resources, along with pagination tokens
           communityResponse = await getCommunityResources(keyword, "4", filterSearch, ascending, sortType, undefined, groupPageNumberRef.current, communityTokenRef.current, PAGE_SIZE);
@@ -149,7 +159,7 @@ export default function HydroShareResourcesSelector({
           searchTokenRef.current = searchResponse?.nextPaginationToken;
         }
 
-        const mappedList = resourceList.map((res) => ({
+        let mappedList = resourceList.map((res) => ({
           resource_id: res.resource_id,
           title: res.resource_title,
           authors: res.authors.map(
@@ -166,9 +176,21 @@ export default function HydroShareResourcesSelector({
           embed_url: "",
         }));
 
-        // Sort locally when fetching datasets to account for curated resources being combined with searched resources
-        if (keyword.includes('data')) {
-          sortResources(mappedList, sortType, sortDirection);
+        // Search locally when ecosystem is selected
+        if (ecosystemSelected) {
+          const searchTerm = filterSearch.trim().toLowerCase();
+          if (searchTerm) {
+            mappedList = mappedList.filter(resource =>
+              resource.title?.toLowerCase().includes(searchTerm) ||
+              resource.authors?.toLowerCase().includes(searchTerm) ||
+              resource.description?.toLowerCase().includes(searchTerm)
+            );
+          }
+        }
+
+        // Sort locally when fetching datasets (or an ecosystem) to account for curated resources being combined with searched resources
+        if (keyword.includes('data') || ecosystemSelected) {
+          mappedList = sortResources(mappedList, sortType, sortDirection);
         }
 
         // Handle first page vs pagination
@@ -222,10 +244,47 @@ export default function HydroShareResourcesSelector({
         fetching.current = false;
       }
     },
-    [keyword, filterSearch, sortDirection, sortType]
+    [keyword, filterSearch, sortDirection, sortType, ecosystem]
   );
 
+  // Fetch ecosystem resources and extract their titles for the ecosystem selector
+  useEffect(() => {
+    try {
+      let cancelled = false;
 
+      // Fetch ecosystem resources asynchronously
+      (async () => {
+        try {
+          // Fetch ecosystem resources from HydroShare using the search API
+          const ecosystemsResponse = await fetchResourcesBySearch('ciroh_hub_ecosystem', '');
+
+          // Make sure the component has not been unmounted before updating state
+          if (!cancelled)
+          {
+            // Extract the titles from the ecosystem resources
+            let ecosystems = [{'name': 'Ecosystem', 'id': ''}];
+
+            for (let resource of ecosystemsResponse.resources) {
+              if (resource?.resource_title && resource?.resource_id) {
+                ecosystems.push({name: resource.resource_title, id: resource.resource_id});
+              }
+            }
+
+            // Update the state with the extracted ecosystem titles
+            setEcosystems(ecosystems);
+          }
+        } catch (error) {
+          if (!cancelled) console.error(error.message);
+        }
+      })();
+
+      // Cleanup function to mark the fetch as cancelled if the component unmounts
+      return () => { cancelled = true; };
+    } 
+    catch (error) {
+      console.error(`Error fetching ecosystem resources: ${error.message}`);
+    }
+  }, []);
 
   // Reset and load first page when filters change
   useEffect(() => {
@@ -254,6 +313,7 @@ export default function HydroShareResourcesSelector({
       filterSearch,
       sortType,
       sortDirection,
+      ecosystem,
       view,
     });
   }, [
@@ -264,6 +324,7 @@ export default function HydroShareResourcesSelector({
     filterSearch,
     sortType,
     sortDirection,
+    ecosystem,
     view,
     onResultsChange,
   ]);
@@ -346,6 +407,18 @@ export default function HydroShareResourcesSelector({
                   }}
                   onBlur={(e) => commitSearch(e.currentTarget.value)}
                 />
+              </div>
+
+              <div className="tw-flex tw-flex-wrap tw-gap-2 tw-items-center">
+                <select
+                  value={ecosystem}
+                  onChange={e => setEcosystem(e.target.value)}
+                  className="tw-rounded-lg tw-border tw-border-slate-200/80 dark:tw-border-slate-700/80 tw-bg-white/80 dark:tw-bg-slate-900/50 tw-backdrop-blur tw-px-3 tw-py-3 tw-text-sm tw-text-slate-900 dark:tw-text-white focus:tw-outline-none focus:tw-ring-2 focus:tw-ring-cyan-500/30"
+                >
+                  {ecosystems.map(({name, id}) => (
+                    <option key={id} value={id}>{name}</option>
+                  ))}
+                </select>
               </div>
 
               <div className="tw-flex tw-flex-wrap tw-gap-2 tw-items-center">

--- a/src/components/HydroShareResourcesSelector/index.js
+++ b/src/components/HydroShareResourcesSelector/index.js
@@ -275,7 +275,7 @@ export default function HydroShareResourcesSelector({
       (async () => {
         try {
           // Fetch ecosystem resources from HydroShare using the search API
-          const ecosystemsResponse = await fetchResourcesBySearch('ciroh_hub_ecosystem', '');
+          const ecosystemsResponse = await fetchResourcesBySearch('ciroh_hub_group', '');
 
           // Make sure the component has not been unmounted before updating state
           if (!cancelled)


### PR DESCRIPTION
Adds a "Group" selector to the HydroShare resource pages that lets users narrow the displayed resources to a curated group (such as NGIAB). When a group is selected, only the collection members that belong on the current page — i.e. are tagged with one of the page's subject keywords such as `ciroh_hub_app` — are shown.

## Additions

- Group selector dropdown on resource pages, populated from HydroShare
  resources tagged `ciroh_hub_group`, with "All" as the default (no
  filter) option
- Labels above the search, group, and sort controls (real `<label>`
  elements, so they're click-to-focus and screen-reader friendly)

## Removals

- `fast-xml-parser` dependency — collection metadata is now fetched as JSON
  from the `scimeta/elements/` endpoint instead of parsed from XML

## Changes

- `fetchResource()` now uses the `scimeta/elements/` endpoint instead of
  `sysmeta/`, remapped to the same field names callers already consume; this
  additionally provides each resource's subjects (needed for keyword
  filtering) and DOI
- HydroShare lists a resource collection's members as citation strings, which cite a
  member either by resource URL or by DOI. `fetchResourcesFromCollection` now
  understands both; previously, DOI-cited members were missed
- `fetchResourcesFromCollection` now handles when a resource is listed twice
- Relation entries that aren't collection members (e.g. `isVersionOf`) are
  now skipped instead of causing an error
- The filter form is bottom-aligned so the controls sit on one line with
  their labels above them

## Testing

1.

## Screenshots

<img width="1901" height="897" alt="image" src="https://github.com/user-attachments/assets/c4b5ae9b-8df6-48ce-9d6e-16b9b6cce617" />


## Notes

## Todos

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
